### PR TITLE
feat!: use more general topic representation for `eth_getLogs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,7 +2124,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=d45824b1bb7616dbce23bfeb21e85e937dfe93a7#d45824b1bb7616dbce23bfeb21e85e937dfe93a7"
+source = "git+https://github.com/rvanasa/ic?rev=5b57b1e6ef128cff1349c49a4a921702c20594de#5b57b1e6ef128cff1349c49a4a921702c20594de"
 dependencies = [
  "base32",
  "byte-unit",
@@ -2167,7 +2167,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=d45824b1bb7616dbce23bfeb21e85e937dfe93a7#d45824b1bb7616dbce23bfeb21e85e937dfe93a7"
+source = "git+https://github.com/rvanasa/ic?rev=5b57b1e6ef128cff1349c49a4a921702c20594de#5b57b1e6ef128cff1349c49a4a921702c20594de"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2285,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=d45824b1bb7616dbce23bfeb21e85e937dfe93a7#d45824b1bb7616dbce23bfeb21e85e937dfe93a7"
+source = "git+https://github.com/rvanasa/ic?rev=5b57b1e6ef128cff1349c49a4a921702c20594de#5b57b1e6ef128cff1349c49a4a921702c20594de"
 dependencies = [
  "candid",
  "serde",
@@ -2417,7 +2417,7 @@ dependencies = [
 [[package]]
 name = "ic-cketh-minter"
 version = "0.1.0"
-source = "git+https://github.com/rvanasa/ic?rev=d45824b1bb7616dbce23bfeb21e85e937dfe93a7#d45824b1bb7616dbce23bfeb21e85e937dfe93a7"
+source = "git+https://github.com/rvanasa/ic?rev=5b57b1e6ef128cff1349c49a4a921702c20594de#5b57b1e6ef128cff1349c49a4a921702c20594de"
 dependencies = [
  "askama",
  "async-trait",
@@ -2552,7 +2552,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=d45824b1bb7616dbce23bfeb21e85e937dfe93a7#d45824b1bb7616dbce23bfeb21e85e937dfe93a7"
+source = "git+https://github.com/rvanasa/ic?rev=5b57b1e6ef128cff1349c49a4a921702c20594de#5b57b1e6ef128cff1349c49a4a921702c20594de"
 dependencies = [
  "k256",
  "lazy_static",
@@ -2871,7 +2871,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=d45824b1bb7616dbce23bfeb21e85e937dfe93a7#d45824b1bb7616dbce23bfeb21e85e937dfe93a7"
+source = "git+https://github.com/rvanasa/ic?rev=5b57b1e6ef128cff1349c49a4a921702c20594de#5b57b1e6ef128cff1349c49a4a921702c20594de"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -3037,7 +3037,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=d45824b1bb7616dbce23bfeb21e85e937dfe93a7#d45824b1bb7616dbce23bfeb21e85e937dfe93a7"
+source = "git+https://github.com/rvanasa/ic?rev=5b57b1e6ef128cff1349c49a4a921702c20594de#5b57b1e6ef128cff1349c49a4a921702c20594de"
 dependencies = [
  "ic-crypto-internal-sha2 0.9.0",
 ]
@@ -3045,7 +3045,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha3"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=d45824b1bb7616dbce23bfeb21e85e937dfe93a7#d45824b1bb7616dbce23bfeb21e85e937dfe93a7"
+source = "git+https://github.com/rvanasa/ic?rev=5b57b1e6ef128cff1349c49a4a921702c20594de#5b57b1e6ef128cff1349c49a4a921702c20594de"
 dependencies = [
  "sha3",
 ]
@@ -3259,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=d45824b1bb7616dbce23bfeb21e85e937dfe93a7#d45824b1bb7616dbce23bfeb21e85e937dfe93a7"
+source = "git+https://github.com/rvanasa/ic?rev=5b57b1e6ef128cff1349c49a4a921702c20594de#5b57b1e6ef128cff1349c49a4a921702c20594de"
 dependencies = [
  "ic-utils 0.9.0",
  "serde",
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=d45824b1bb7616dbce23bfeb21e85e937dfe93a7#d45824b1bb7616dbce23bfeb21e85e937dfe93a7"
+source = "git+https://github.com/rvanasa/ic?rev=5b57b1e6ef128cff1349c49a4a921702c20594de#5b57b1e6ef128cff1349c49a4a921702c20594de"
 dependencies = [
  "candid",
  "ic-base-types 0.9.0",
@@ -3636,7 +3636,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=d45824b1bb7616dbce23bfeb21e85e937dfe93a7#d45824b1bb7616dbce23bfeb21e85e937dfe93a7"
+source = "git+https://github.com/rvanasa/ic?rev=5b57b1e6ef128cff1349c49a4a921702c20594de#5b57b1e6ef128cff1349c49a4a921702c20594de"
 dependencies = [
  "bincode",
  "candid",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=d45824b1bb7616dbce23bfeb21e85e937dfe93a7#d45824b1bb7616dbce23bfeb21e85e937dfe93a7"
+source = "git+https://github.com/rvanasa/ic?rev=5b57b1e6ef128cff1349c49a4a921702c20594de#5b57b1e6ef128cff1349c49a4a921702c20594de"
 dependencies = [
  "hex",
  "ic-crypto-sha2 0.9.0",
@@ -4100,7 +4100,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=d45824b1bb7616dbce23bfeb21e85e937dfe93a7#d45824b1bb7616dbce23bfeb21e85e937dfe93a7"
+source = "git+https://github.com/rvanasa/ic?rev=5b57b1e6ef128cff1349c49a4a921702c20594de#5b57b1e6ef128cff1349c49a4a921702c20594de"
 dependencies = [
  "cvt",
  "hex",
@@ -4117,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "ic-utils-ensure"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=d45824b1bb7616dbce23bfeb21e85e937dfe93a7#d45824b1bb7616dbce23bfeb21e85e937dfe93a7"
+source = "git+https://github.com/rvanasa/ic?rev=5b57b1e6ef128cff1349c49a4a921702c20594de#5b57b1e6ef128cff1349c49a4a921702c20594de"
 
 [[package]]
 name = "ic-utils-lru-cache"
@@ -4195,7 +4195,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?rev=d45824b1bb7616dbce23bfeb21e85e937dfe93a7#d45824b1bb7616dbce23bfeb21e85e937dfe93a7"
+source = "git+https://github.com/rvanasa/ic?rev=5b57b1e6ef128cff1349c49a4a921702c20594de#5b57b1e6ef128cff1349c49a4a921702c20594de"
 dependencies = [
  "async-trait",
  "candid",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client-cdk"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?rev=d45824b1bb7616dbce23bfeb21e85e937dfe93a7#d45824b1bb7616dbce23bfeb21e85e937dfe93a7"
+source = "git+https://github.com/rvanasa/ic?rev=5b57b1e6ef128cff1349c49a4a921702c20594de#5b57b1e6ef128cff1349c49a4a921702c20594de"
 dependencies = [
  "async-trait",
  "candid",
@@ -4232,7 +4232,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.4"
-source = "git+https://github.com/rvanasa/ic?rev=d45824b1bb7616dbce23bfeb21e85e937dfe93a7#d45824b1bb7616dbce23bfeb21e85e937dfe93a7"
+source = "git+https://github.com/rvanasa/ic?rev=5b57b1e6ef128cff1349c49a4a921702c20594de#5b57b1e6ef128cff1349c49a4a921702c20594de"
 dependencies = [
  "base32",
  "candid",
@@ -5178,7 +5178,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=d45824b1bb7616dbce23bfeb21e85e937dfe93a7#d45824b1bb7616dbce23bfeb21e85e937dfe93a7"
+source = "git+https://github.com/rvanasa/ic?rev=5b57b1e6ef128cff1349c49a4a921702c20594de#5b57b1e6ef128cff1349c49a4a921702c20594de"
 dependencies = [
  "candid",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ic-stable-structures = { workspace = true }
 ic-certified-map = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
-cketh-common = { git = "https://github.com/rvanasa/ic", rev = "d45824b1bb7616dbce23bfeb21e85e937dfe93a7", package = "ic-cketh-minter" }
+cketh-common = { git = "https://github.com/rvanasa/ic", rev = "5b57b1e6ef128cff1349c49a4a921702c20594de", package = "ic-cketh-minter" }
 maplit = "1.0"
 num = "0.4"
 num-traits = "0.2"

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -53,7 +53,7 @@ type GetLogsArgs = record {
   fromBlock : opt BlockTag;
   toBlock : opt BlockTag;
   addresses : vec text;
-  topics : opt vec text;
+  topics : opt vec vec text;
 };
 type GetTransactionCountArgs = record { address : text; block : BlockTag };
 type HttpHeader = record { value : text; name : text };

--- a/e2e/motoko/Main.mo
+++ b/e2e/motoko/Main.mo
@@ -171,10 +171,16 @@ shared ({ caller = installer }) actor class Main() {
                     ethMainnetSource,
                     null,
                     {
-                        addresses = ["0xdAC17F958D2ee523a2206206994597C13D831ec7"];
+                        addresses = ["0xB9B002e70AdF0F544Cd0F6b80BF12d4925B0695F"];
                         fromBlock = null;
                         toBlock = null;
-                        topics = null;
+                        topics = ?[
+                            ["0x4d69d0bd4287b7f66c548f90154dc81bc98f65a1b362775df5ae171a2ccd262b"],
+                            [
+                                "0x000000000000000000000000352413d00d2963dfc58bc2d6c57caca1e714d428",
+                                "0x000000000000000000000000b6bc16189ec3d33041c893b44511c594b1736b8a",
+                            ],
+                        ];
                     },
                 ),
             );

--- a/src/types.rs
+++ b/src/types.rs
@@ -557,7 +557,7 @@ pub enum RpcSource {
 }
 
 pub mod candid_types {
-    use std::{ops::Try, str::FromStr};
+    use std::str::FromStr;
 
     use candid::CandidType;
     use cketh_common::{

--- a/src/types.rs
+++ b/src/types.rs
@@ -602,7 +602,6 @@ pub mod candid_types {
         #[serde(rename = "toBlock")]
         pub to_block: Option<BlockTag>,
         pub addresses: Vec<String>,
-        #[serde(flatten)]
         pub topics: Option<Vec<Vec<String>>>,
     }
 


### PR DESCRIPTION
Changes the Candid type of the `topics` field to `vec vec text` instead of `vec text`. 

For example, `vec {"0xabc", "0x123"}` is now equivalent to `vec {vec {"0xabc"}; vec {"0xdef"}}`. Passing multiple `text` values corresponds to the "or" operation within the topics. 