### PR TITLE
fix: miscellaneous

### DIFF
--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -87,10 +87,9 @@ type LogEntry = record {
   removed : bool;
 };
 type ManageProviderArgs = record {
-  "service" : opt RpcService;
-  owner : opt principal;
-  primary : opt bool;
   providerId : nat64;
+  "service" : opt RpcService;
+  primary : opt bool;
 };
 type Metrics = record {
   requests : vec record { record { text; text }; nat64 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::ffi::OsStr;
+
 use candid::candid_method;
 use cketh_common::eth_rpc::{Block, FeeHistory, LogEntry, RpcError, SendRawTransactionResult};
 
@@ -256,8 +258,24 @@ fn http_request(request: AssetHttpRequest) -> AssetHttpResponse {
                 }
             }
 
-            log.entries
-                .retain(|entry| entry.timestamp >= max_skip_timestamp);
+            log.entries = log
+                .entries
+                .into_iter()
+                .filter(|entry| entry.timestamp >= max_skip_timestamp)
+                .map(|mut entry| {
+                    // Remove absolute file paths
+                    if !entry.file.starts_with("src/") {
+                        entry.file = format!(
+                            ".../{}",
+                            std::path::Path::new(&OsStr::new(&entry.file))
+                                .file_name()
+                                .and_then(|s| s.to_str())
+                                .unwrap_or("<unknown>"),
+                        );
+                    }
+                    entry
+                })
+                .collect();
 
             fn ordering_from_query_params(sort: Option<&str>, max_skip_timestamp: u64) -> Sort {
                 match sort {


### PR DESCRIPTION
* Removes the unused `ManageProviderArgs.owner` field in the Candid interface
* Redacts absolute file paths (corner case / bug with the `ic-canister-logs` crate)
