### PR TITLE
test(e2e): number of nodes in subnet

### DIFF
--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -87,10 +87,9 @@ type LogEntry = record {
   removed : bool;
 };
 type ManageProviderArgs = record {
-  "service" : opt RpcService;
-  owner : opt principal;
-  primary : opt bool;
   providerId : nat64;
+  "service" : opt RpcService;
+  primary : opt bool;
 };
 type Metrics = record {
   requests : vec record { record { text; text }; nat64 };

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -238,6 +238,7 @@ service : (InitArgs) -> {
   getAccumulatedCycleCount : (nat64) -> (nat) query;
   getAuthorized : (Auth) -> (vec principal) query;
   getMetrics : () -> (Metrics) query;
+  getNodesInSubnet : () -> (nat32) query;
   getOpenRpcAccess : () -> (bool) query;
   getProviders : () -> (vec ProviderView) query;
   getServiceProviderMap : () -> (vec record { RpcService; nat64 }) query;

--- a/dfx.json
+++ b/dfx.json
@@ -10,9 +10,10 @@
       },
       "pullable": {
         "dependencies": [],
-        "wasm_url": "https://github.com/internet-computer-protocol/evm-rpc-canister/releases/latest/download/evm_rpc.wasm",
+        "wasm_url": "https://github.com/internet-computer-protocol/evm-rpc-canister/releases/latest/download/evm_rpc.wasm.gz",
         "init_guide": "Number of nodes in the subnet, e.g. '(record {nodesInSubnet = 28})'"
-      }
+      },
+      "gzip": true
     },
     "evm_rpc_staging_13_node": {
       "candid": "candid/evm_rpc.did",

--- a/dfx.json
+++ b/dfx.json
@@ -10,7 +10,7 @@
       },
       "pullable": {
         "dependencies": [],
-        "wasm_url": "https://github.com/internet-computer-protocol/ic-eth-rpc/releases/latest/download/evm_rpc_dev.wasm.gz",
+        "wasm_url": "https://github.com/internet-computer-protocol/evm-rpc-canister/releases/latest/download/evm_rpc.wasm",
         "init_guide": "Number of nodes in the subnet, e.g. '(record {nodesInSubnet = 28})'"
       }
     },

--- a/dfx.json
+++ b/dfx.json
@@ -18,12 +18,14 @@
     "evm_rpc_staging_13_node": {
       "candid": "candid/evm_rpc.did",
       "type": "rust",
-      "package": "evm_rpc"
+      "package": "evm_rpc",
+      "gzip": true
     },
     "evm_rpc_staging_fiduciary": {
       "candid": "candid/evm_rpc.did",
       "type": "rust",
-      "package": "evm_rpc"
+      "package": "evm_rpc",
+      "gzip": true
     },
     "e2e_rust": {
       "dependencies": [

--- a/dfx.json
+++ b/dfx.json
@@ -28,11 +28,7 @@
       "gzip": true
     },
     "e2e_rust": {
-      "dependencies": [
-        "evm_rpc",
-        "evm_rpc_staging_13_node",
-        "evm_rpc_staging_fiduciary"
-      ],
+      "dependencies": ["evm_rpc_staging_fiduciary"],
       "candid": "e2e/rust/e2e_rust.did",
       "type": "rust",
       "package": "e2e"

--- a/e2e/motoko/Main.mo
+++ b/e2e/motoko/Main.mo
@@ -14,13 +14,13 @@ shared ({ caller = installer }) actor class Main() {
 
     type TestCategory = { #staging; #production };
 
+    // (`subnet name`, `nodes in subnet`, `expected cycles for JSON-RPC call`)
     type SubnetTarget = (Text, Nat32, Nat);
-    // (`nodes in subnet`, `expected cycles for JSON-RPC call`)
     let defaultSubnet: SubnetTarget = ("13-node", 13, 99_330_400);
     let fiduciarySubnet: SubnetTarget = ("fiduciary", 28, 239_142_400);
 
     let testTargets = [
-        // (`subnet name`, `canister module`, `canister type`, `subnet`)
+        // (`canister module`, `canister type`, `subnet`)
         (EvmRpcStaging13Node, #staging, defaultSubnet),
         (EvmRpcStagingFidicuary, #staging, fiduciarySubnet),
         (EvmRpcProductionFiduciary, #production, fiduciarySubnet),

--- a/e2e/motoko/Main.mo
+++ b/e2e/motoko/Main.mo
@@ -31,14 +31,6 @@ shared ({ caller = installer }) actor class Main() {
         (#EthMainnet(#BlockPi), "eth_sendRawTransaction"), // "Private transaction replacement (same nonce) with gas price change lower than 10% is not allowed within 30 sec from the previous transaction."
     ];
 
-    public shared ({ caller }) func test() : async () {
-        await runTests(caller, #staging);
-    };
-
-    public shared ({ caller }) func testProduction() : async () {
-        await runTests(caller, #production);
-    };
-
     func runTests(caller : Principal, category : TestCategory) : async () {
         assert caller == installer;
 
@@ -241,5 +233,13 @@ shared ({ caller = installer }) actor class Main() {
             };
             Debug.trap(message);
         };
+    };
+
+    public shared ({ caller }) func test() : async () {
+        await runTests(caller, #staging);
+    };
+
+    public shared ({ caller }) func testProduction() : async () {
+        await runTests(caller, #production);
     };
 };

--- a/e2e/motoko/Main.mo
+++ b/e2e/motoko/Main.mo
@@ -1,23 +1,23 @@
+import EvmRpcProductionFiduciary "canister:evm_rpc";
 import EvmRpcStaging13Node "canister:evm_rpc_staging_13_node";
 import EvmRpcStagingFidicuary "canister:evm_rpc_staging_fiduciary";
-import EvmRpcProductionFiduciary "canister:evm_rpc";
 
 import Blob "mo:base/Blob";
+import Buffer "mo:base/Buffer";
 import Debug "mo:base/Debug";
 import Cycles "mo:base/ExperimentalCycles";
 import Principal "mo:base/Principal";
 import Text "mo:base/Text";
-import Buffer "mo:base/Buffer";
 import Evm "mo:evm";
 
 shared ({ caller = installer }) actor class Main() {
 
     type TestCategory = { #staging; #production };
 
-    type SubnetTarget = (Nat, Nat);
+    type SubnetTarget = (Text, Nat32, Nat);
     // (`nodes in subnet`, `expected cycles for JSON-RPC call`)
-    let defaultSubnet = ("13-node", 13, 99_330_400);
-    let fiduciarySubnet = ("fiduciary", 28, 239_142_400);
+    let defaultSubnet: SubnetTarget = ("13-node", 13, 99_330_400);
+    let fiduciarySubnet: SubnetTarget = ("fiduciary", 28, 239_142_400);
 
     let testTargets = [
         // (`subnet name`, `canister module`, `canister type`, `subnet`)
@@ -65,6 +65,12 @@ shared ({ caller = installer }) actor class Main() {
             };
             let json = "{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":null,\"id\":1}";
             let maxResponseBytes : Nat64 = 1000;
+
+            // Nodes in subnet
+            let actualNodesInSubnet = await canister.getNodesInSubnet();
+            if (actualNodesInSubnet != nodesInSubnet) {
+                addError("Unexpected number of nodes in subnet (received " # debug_show actualNodesInSubnet # ", expected " # debug_show nodesInSubnet # ")");
+            };
 
             // `requestCost()`
             let cyclesResult = await canister.requestCost(source, json, maxResponseBytes);

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -2,7 +2,6 @@
 # Reinstall all canisters and run E2E tests in your local environment.
 (
     dfx canister create --all &&
-    dfx build &&
     dfx deploy evm_rpc --argument "(record {nodesInSubnet = 28})" --mode reinstall -y &&
     dfx deploy evm_rpc_staging_13_node --argument "(record {nodesInSubnet = 13})" --mode reinstall -y &&
     dfx deploy evm_rpc_staging_fiduciary --argument "(record {nodesInSubnet = 28})" --mode reinstall -y &&

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -2,13 +2,14 @@
 # Reinstall all canisters and run E2E tests in your local environment.
 (
     dfx canister create --all &&
+    dfx build &&
     dfx deploy evm_rpc --argument "(record {nodesInSubnet = 28})" --mode reinstall -y &&
     dfx deploy evm_rpc_staging_13_node --argument "(record {nodesInSubnet = 13})" --mode reinstall -y &&
     dfx deploy evm_rpc_staging_fiduciary --argument "(record {nodesInSubnet = 28})" --mode reinstall -y &&
     npm run generate &&
-    dfx deploy e2e_rust &&
+    dfx canister install e2e_rust &&
     dfx canister call e2e_rust test &&
-    dfx deploy e2e_motoko &&
+    dfx canister install e2e_motoko &&
     dfx canister call e2e_motoko test &&
     echo Done
 )

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -7,9 +7,9 @@
     dfx deploy evm_rpc_staging_13_node --argument "(record {nodesInSubnet = 13})" --mode reinstall -y &&
     dfx deploy evm_rpc_staging_fiduciary --argument "(record {nodesInSubnet = 28})" --mode reinstall -y &&
     npm run generate &&
-    dfx canister install e2e_rust &&
+    dfx deploy e2e_rust &&
     dfx canister call e2e_rust test &&
-    dfx canister install e2e_motoko &&
+    dfx deploy e2e_motoko &&
     dfx canister call e2e_motoko test &&
     echo Done
 )

--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -153,6 +153,7 @@ fn test_candid_rpc_cost() {
     let provider = PROVIDERS.with(|providers| providers.borrow().get(&provider_id).unwrap());
 
     // Default subnet
+    UNSTABLE_SUBNET_SIZE.with(|n| *n.borrow_mut() = NODES_IN_DEFAULT_SUBNET);
     assert_eq!(
         [
             get_candid_rpc_cost(&provider, 0, 0),

--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -59,7 +59,7 @@ pub fn get_provider_cost(provider: &Provider, payload_size_bytes: u64) -> u128 {
 
 #[test]
 fn test_request_cost() {
-    for nodes_in_subnet in [1, NODES_IN_DEFAULT_SUBNET, NODES_IN_FIDUCIARY_SUBNET] {
+    for nodes_in_subnet in [1, NODES_IN_STANDARD_SUBNET, NODES_IN_FIDUCIARY_SUBNET] {
         println!("Nodes in subnet: {nodes_in_subnet}");
 
         UNSTABLE_SUBNET_SIZE.with(|n| *n.borrow_mut() = nodes_in_subnet);
@@ -91,7 +91,7 @@ fn test_request_cost() {
 
 #[test]
 fn test_provider_cost() {
-    for nodes_in_subnet in [1, NODES_IN_DEFAULT_SUBNET, NODES_IN_FIDUCIARY_SUBNET] {
+    for nodes_in_subnet in [1, NODES_IN_STANDARD_SUBNET, NODES_IN_FIDUCIARY_SUBNET] {
         println!("Nodes in subnet: {nodes_in_subnet}");
 
         UNSTABLE_SUBNET_SIZE.with(|n| *n.borrow_mut() = nodes_in_subnet);
@@ -152,8 +152,8 @@ fn test_candid_rpc_cost() {
     );
     let provider = PROVIDERS.with(|providers| providers.borrow().get(&provider_id).unwrap());
 
-    // Default subnet
-    UNSTABLE_SUBNET_SIZE.with(|n| *n.borrow_mut() = NODES_IN_DEFAULT_SUBNET);
+    // 13-node subnet
+    UNSTABLE_SUBNET_SIZE.with(|n| *n.borrow_mut() = NODES_IN_STANDARD_SUBNET);
     assert_eq!(
         [
             get_candid_rpc_cost(&provider, 0, 0),

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -26,7 +26,7 @@ pub const WASM_PAGE_SIZE: u64 = 65536;
 
 pub const ETH_GET_LOGS_MAX_BLOCKS: u32 = 500;
 
-pub const NODES_IN_DEFAULT_SUBNET: u32 = 13;
+pub const NODES_IN_STANDARD_SUBNET: u32 = 13;
 pub const NODES_IN_FIDUCIARY_SUBNET: u32 = 28;
 pub const DEFAULT_OPEN_RPC_ACCESS: bool = true;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,6 +185,12 @@ fn get_service_provider_map() -> Vec<(RpcService, u64)> {
     })
 }
 
+#[query(name = "getNodesInSubnet")]
+#[candid_method(query, rename = "getNodesInSubnet")]
+async fn get_nodes_in_subnet() -> u32 {
+    UNSTABLE_SUBNET_SIZE.with(|n| *n.borrow())
+}
+
 #[query(name = "getAccumulatedCycleCount")]
 #[candid_method(query, rename = "getAccumulatedCycleCount")]
 fn get_accumulated_cycle_count(provider_id: u64) -> u128 {
@@ -206,7 +212,7 @@ fn transform(args: TransformArgs) -> HttpResponse {
 
 #[ic_cdk::init]
 fn init(args: InitArgs) {
-    UNSTABLE_SUBNET_SIZE.with(|m| *m.borrow_mut() = args.nodes_in_subnet);
+    post_upgrade(args);
 
     for provider in get_default_providers() {
         do_register_provider(ic_cdk::caller(), provider);
@@ -222,6 +228,11 @@ fn init(args: InitArgs) {
                 });
         set_service_provider(&service, &provider);
     }
+}
+
+#[ic_cdk::post_upgrade]
+fn post_upgrade(args: InitArgs) {
+    UNSTABLE_SUBNET_SIZE.with(|m| *m.borrow_mut() = args.nodes_in_subnet);
 }
 
 #[query]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::ffi::OsStr;
+
 use candid::candid_method;
 use cketh_common::eth_rpc::{Block, FeeHistory, LogEntry, RpcError, SendRawTransactionResult};
 
@@ -256,8 +258,24 @@ fn http_request(request: AssetHttpRequest) -> AssetHttpResponse {
                 }
             }
 
-            log.entries
-                .retain(|entry| entry.timestamp >= max_skip_timestamp);
+            log.entries = log
+                .entries
+                .into_iter()
+                .filter(|entry| entry.timestamp >= max_skip_timestamp)
+                .map(|mut entry| {
+                    // Remove absolute file paths
+                    if !entry.file.starts_with("src/") {
+                        entry.file = format!(
+                            ".../{}",
+                            std::path::Path::new(&OsStr::new(&entry.file))
+                                .file_name()
+                                .and_then(|s| s.to_str())
+                                .unwrap_or("<unknown>"),
+                        );
+                    }
+                    entry
+                })
+                .collect();
 
             fn ordering_from_query_params(sort: Option<&str>, max_skip_timestamp: u64) -> Sort {
                 match sort {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -6,7 +6,7 @@ use ic_stable_structures::VectorMemory;
 use ic_stable_structures::{Cell, StableBTreeMap};
 use std::cell::RefCell;
 
-use crate::{types::*, NODES_IN_DEFAULT_SUBNET};
+use crate::{types::*, NODES_IN_FIDUCIARY_SUBNET};
 
 #[cfg(not(target_arch = "wasm32"))]
 type Memory = VirtualMemory<VectorMemory>;
@@ -16,7 +16,7 @@ type Memory = VirtualMemory<DefaultMemoryImpl>;
 thread_local! {
     // Unstable static data: this is reset when the canister is upgraded.
     pub static UNSTABLE_METRICS: RefCell<Metrics> = RefCell::new(Metrics::default());
-    pub static UNSTABLE_SUBNET_SIZE: RefCell<u32> = RefCell::new(NODES_IN_DEFAULT_SUBNET);
+    pub static UNSTABLE_SUBNET_SIZE: RefCell<u32> = RefCell::new(NODES_IN_FIDUCIARY_SUBNET);
 
     // Stable static data: this is preserved when the canister is upgraded.
     #[cfg(not(target_arch = "wasm32"))]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -82,7 +82,7 @@ impl EvmRpcSetup {
         );
 
         let args = InitArgs {
-            nodes_in_subnet: NODES_IN_DEFAULT_SUBNET,
+            nodes_in_subnet: NODES_IN_STANDARD_SUBNET,
         };
 
         let controller = PrincipalId::new_user_test_id(DEFAULT_CONTROLLER_TEST_ID);


### PR DESCRIPTION
Adds a test for the number of subnet nodes and makes several changes to minimize the chance of the number unexpectedly changing after upgrading the canister. 

Includes changes from #168 (merging this afterwards).
