### PR TITLE
fix: rewrite absolute paths in log messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,7 +1584,7 @@ dependencies = [
  "getrandom 0.2.12",
  "hex",
  "ic-base-types 0.8.0",
- "ic-canister-log 0.2.0 (git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd)",
+ "ic-canister-log 0.2.0 (git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd)",
  "ic-canisters-http-types 0.8.0",
  "ic-cdk",
  "ic-cdk-macros",
@@ -2242,7 +2242,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "base32",
  "byte-unit",
@@ -2285,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2298,7 +2298,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "serde",
 ]
@@ -2402,7 +2402,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "candid",
  "serde",
@@ -2534,7 +2534,7 @@ dependencies = [
 [[package]]
 name = "ic-cketh-minter"
 version = "0.1.0"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "askama",
  "async-trait",
@@ -2543,7 +2543,7 @@ dependencies = [
  "futures",
  "hex",
  "hex-literal 0.4.1",
- "ic-canister-log 0.2.0 (git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd)",
+ "ic-canister-log 0.2.0 (git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd)",
  "ic-canisters-http-types 0.9.0",
  "ic-cdk",
  "ic-cdk-macros",
@@ -2669,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "k256",
  "lazy_static",
@@ -2988,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -3154,7 +3154,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "ic-crypto-internal-sha2 0.9.0",
 ]
@@ -3162,7 +3162,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha3"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "sha3 0.9.1",
 ]
@@ -3376,7 +3376,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "ic-utils 0.9.0",
  "serde",
@@ -3463,7 +3463,7 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "candid",
  "ic-base-types 0.9.0",
@@ -3753,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "bincode",
  "candid",
@@ -4075,7 +4075,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "hex",
  "ic-crypto-sha2 0.9.0",
@@ -4217,7 +4217,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "cvt",
  "hex",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "ic-utils-ensure"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 
 [[package]]
 name = "ic-utils-lru-cache"
@@ -4312,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "async-trait",
  "candid",
@@ -4323,7 +4323,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client-cdk"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "async-trait",
  "candid",
@@ -4349,7 +4349,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.4"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "base32",
  "candid",
@@ -5401,7 +5401,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
+source = "git+https://github.com/dfinity/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "candid",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,7 +1584,7 @@ dependencies = [
  "getrandom 0.2.12",
  "hex",
  "ic-base-types 0.8.0",
- "ic-canister-log 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-canister-log 0.2.0 (git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd)",
  "ic-canisters-http-types 0.8.0",
  "ic-cdk",
  "ic-cdk-macros",
@@ -2242,7 +2242,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=8511846fb6352a0a4f9abae1a8fc8569aeba5f10#8511846fb6352a0a4f9abae1a8fc8569aeba5f10"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "base32",
  "byte-unit",
@@ -2285,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=8511846fb6352a0a4f9abae1a8fc8569aeba5f10#8511846fb6352a0a4f9abae1a8fc8569aeba5f10"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2298,8 +2298,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb82c4f617ecff6e452fe65af0489626ec7330ffe3eedd9ea14e6178eea48d1a"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "serde",
 ]
@@ -2403,7 +2402,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=8511846fb6352a0a4f9abae1a8fc8569aeba5f10#8511846fb6352a0a4f9abae1a8fc8569aeba5f10"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "candid",
  "serde",
@@ -2535,7 +2534,7 @@ dependencies = [
 [[package]]
 name = "ic-cketh-minter"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=8511846fb6352a0a4f9abae1a8fc8569aeba5f10#8511846fb6352a0a4f9abae1a8fc8569aeba5f10"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "askama",
  "async-trait",
@@ -2544,7 +2543,7 @@ dependencies = [
  "futures",
  "hex",
  "hex-literal 0.4.1",
- "ic-canister-log 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-canister-log 0.2.0 (git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd)",
  "ic-canisters-http-types 0.9.0",
  "ic-cdk",
  "ic-cdk-macros",
@@ -2670,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=8511846fb6352a0a4f9abae1a8fc8569aeba5f10#8511846fb6352a0a4f9abae1a8fc8569aeba5f10"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "k256",
  "lazy_static",
@@ -2989,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=8511846fb6352a0a4f9abae1a8fc8569aeba5f10#8511846fb6352a0a4f9abae1a8fc8569aeba5f10"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -3155,7 +3154,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=8511846fb6352a0a4f9abae1a8fc8569aeba5f10#8511846fb6352a0a4f9abae1a8fc8569aeba5f10"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "ic-crypto-internal-sha2 0.9.0",
 ]
@@ -3163,7 +3162,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha3"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=8511846fb6352a0a4f9abae1a8fc8569aeba5f10#8511846fb6352a0a4f9abae1a8fc8569aeba5f10"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "sha3 0.9.1",
 ]
@@ -3377,7 +3376,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=8511846fb6352a0a4f9abae1a8fc8569aeba5f10#8511846fb6352a0a4f9abae1a8fc8569aeba5f10"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "ic-utils 0.9.0",
  "serde",
@@ -3464,7 +3463,7 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=8511846fb6352a0a4f9abae1a8fc8569aeba5f10#8511846fb6352a0a4f9abae1a8fc8569aeba5f10"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "candid",
  "ic-base-types 0.9.0",
@@ -3754,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=8511846fb6352a0a4f9abae1a8fc8569aeba5f10#8511846fb6352a0a4f9abae1a8fc8569aeba5f10"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "bincode",
  "candid",
@@ -4076,7 +4075,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=8511846fb6352a0a4f9abae1a8fc8569aeba5f10#8511846fb6352a0a4f9abae1a8fc8569aeba5f10"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "hex",
  "ic-crypto-sha2 0.9.0",
@@ -4218,7 +4217,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=8511846fb6352a0a4f9abae1a8fc8569aeba5f10#8511846fb6352a0a4f9abae1a8fc8569aeba5f10"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "cvt",
  "hex",
@@ -4235,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "ic-utils-ensure"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=8511846fb6352a0a4f9abae1a8fc8569aeba5f10#8511846fb6352a0a4f9abae1a8fc8569aeba5f10"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 
 [[package]]
 name = "ic-utils-lru-cache"
@@ -4313,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=8511846fb6352a0a4f9abae1a8fc8569aeba5f10#8511846fb6352a0a4f9abae1a8fc8569aeba5f10"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "async-trait",
  "candid",
@@ -4324,7 +4323,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client-cdk"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=8511846fb6352a0a4f9abae1a8fc8569aeba5f10#8511846fb6352a0a4f9abae1a8fc8569aeba5f10"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "async-trait",
  "candid",
@@ -4350,7 +4349,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.4"
-source = "git+https://github.com/dfinity/ic?rev=8511846fb6352a0a4f9abae1a8fc8569aeba5f10#8511846fb6352a0a4f9abae1a8fc8569aeba5f10"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "base32",
  "candid",
@@ -5402,7 +5401,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=8511846fb6352a0a4f9abae1a8fc8569aeba5f10#8511846fb6352a0a4f9abae1a8fc8569aeba5f10"
+source = "git+https://github.com/rvanasa/ic?rev=22b875f2b9508739b005d4352c14e877995f52fd#22b875f2b9508739b005d4352c14e877995f52fd"
 dependencies = [
  "candid",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ inherits = "release"
 [dependencies]
 candid = { workspace = true }
 getrandom = { workspace = true }
-ic-canister-log = { workspace = true }
 ic-canisters-http-types = { workspace = true }
 ic-nervous-system-common = { workspace = true }
 ic-metrics-encoder = { workspace = true }
@@ -27,7 +26,8 @@ ic-stable-structures = { workspace = true }
 ic-certified-map = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
-cketh-common = { git = "https://github.com/dfinity/ic", rev = "832120fbe5e665e05d32d767deeedbed0252001a", package = "ic-cketh-minter" }
+ic-canister-log = { git = "https://github.com/rvanasa/ic", rev = "22b875f2b9508739b005d4352c14e877995f52fd", package = "ic-canister-log" }
+cketh-common = { git = "https://github.com/rvanasa/ic", rev = "22b875f2b9508739b005d4352c14e877995f52fd", package = "ic-cketh-minter" }
 maplit = "1.0"
 num = "0.4"
 num-traits = "0.2"
@@ -49,7 +49,6 @@ assert_matches = "1.5"
 
 [workspace.dependencies]
 candid = { version = "0.9" }
-ic-canister-log = "0.2.0"
 getrandom = { version = "0.2", features = ["custom"] }
 ic-canisters-http-types = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
 ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ic-stable-structures = { workspace = true }
 ic-certified-map = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
-cketh-common = { git = "https://github.com/dfinity/ic", rev = "6a92358bb862d815e16a071228aa64588015da39", package = "ic-cketh-minter" }
+cketh-common = { git = "https://github.com/dfinity/ic", rev = "832120fbe5e665e05d32d767deeedbed0252001a", package = "ic-cketh-minter" }
 maplit = "1.0"
 num = "0.4"
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ic-stable-structures = { workspace = true }
 ic-certified-map = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
-cketh-common = { git = "https://github.com/dfinity/ic", rev = "8511846fb6352a0a4f9abae1a8fc8569aeba5f10", package = "ic-cketh-minter" }
+cketh-common = { git = "https://github.com/dfinity/ic", rev = "5c0c17c44689dc943edf96481a6325089102f689", package = "ic-cketh-minter" }
 maplit = "1.0"
 num = "0.4"
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ic-stable-structures = { workspace = true }
 ic-certified-map = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
-cketh-common = { git = "https://github.com/dfinity/ic", rev = "5c0c17c44689dc943edf96481a6325089102f689", package = "ic-cketh-minter" }
+cketh-common = { git = "https://github.com/dfinity/ic", rev = "6a92358bb862d815e16a071228aa64588015da39", package = "ic-cketh-minter" }
 maplit = "1.0"
 num = "0.4"
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ ic-stable-structures = { workspace = true }
 ic-certified-map = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
-ic-canister-log = { git = "https://github.com/rvanasa/ic", rev = "22b875f2b9508739b005d4352c14e877995f52fd", package = "ic-canister-log" }
-cketh-common = { git = "https://github.com/rvanasa/ic", rev = "22b875f2b9508739b005d4352c14e877995f52fd", package = "ic-cketh-minter" }
+ic-canister-log = { git = "https://github.com/dfinity/ic", rev = "22b875f2b9508739b005d4352c14e877995f52fd", package = "ic-canister-log" }
+cketh-common = { git = "https://github.com/dfinity/ic", rev = "22b875f2b9508739b005d4352c14e877995f52fd", package = "ic-cketh-minter" }
 maplit = "1.0"
 num = "0.4"
 num-traits = "0.2"

--- a/e2e/motoko/Main.mo
+++ b/e2e/motoko/Main.mo
@@ -191,8 +191,8 @@ shared ({ caller = installer }) actor class Main() {
                         null,
                         {
                             addresses = ["0xB9B002e70AdF0F544Cd0F6b80BF12d4925B0695F"];
-                            fromBlock = null;
-                            toBlock = null;
+                            fromBlock = ?#Number 19520540;
+                            toBlock = ?#Number 19520940;
                             topics = ?[
                                 ["0x4d69d0bd4287b7f66c548f90154dc81bc98f65a1b362775df5ae171a2ccd262b"],
                                 [

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-use std::ffi::OsStr;
-
 use candid::candid_method;
 use cketh_common::eth_rpc::{Block, FeeHistory, LogEntry, RpcError};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,19 +274,6 @@ fn http_request(request: AssetHttpRequest) -> AssetHttpResponse {
                 .entries
                 .into_iter()
                 .filter(|entry| entry.timestamp >= max_skip_timestamp)
-                .map(|mut entry| {
-                    // Remove absolute file paths
-                    if !entry.file.starts_with("src/") {
-                        entry.file = format!(
-                            ".../{}",
-                            std::path::Path::new(&OsStr::new(&entry.file))
-                                .file_name()
-                                .and_then(|s| s.to_str())
-                                .unwrap_or("<unknown>"),
-                        );
-                    }
-                    entry
-                })
                 .collect();
 
             fn ordering_from_query_params(sort: Option<&str>, max_skip_timestamp: u64) -> Sort {

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,11 +268,8 @@ fn http_request(request: AssetHttpRequest) -> AssetHttpResponse {
                 }
             }
 
-            log.entries = log
-                .entries
-                .into_iter()
-                .filter(|entry| entry.timestamp >= max_skip_timestamp)
-                .collect();
+            log.entries
+                .retain(|entry| entry.timestamp >= max_skip_timestamp);
 
             fn ordering_from_query_params(sort: Option<&str>, max_skip_timestamp: u64) -> Sort {
                 match sort {


### PR DESCRIPTION
This PR patches what might be considered a bug with [`ic-canister-log`](https://crates.io/crates/ic-canister-log) which occurs when creating log messages from external crates. When calling from an external crate, log messages may include absolute file paths from the machine that built the Wasm file. We fix this by truncating unknown file paths.

Corresponding MR: [!18445](https://gitlab.com/dfinity-lab/public/ic/-/merge_requests/18445).

Note that the CI for this PR depends on [!18445](https://gitlab.com/dfinity-lab/public/ic/-/merge_requests/18445) being merged.