### PR TITLE
rpc: update default Public Node JSON-RPC URLs

### DIFF
--- a/src/providers.rs
+++ b/src/providers.rs
@@ -14,8 +14,8 @@ pub const ALCHEMY_ETH_SEPOLIA_HOSTNAME: &str = "eth-sepolia.g.alchemy.com";
 pub const CLOUDFLARE_HOSTNAME: &str = "cloudflare-eth.com";
 pub const BLOCKPI_ETH_MAINNET_HOSTNAME: &str = "ethereum.blockpi.network";
 pub const BLOCKPI_ETH_SEPOLIA_HOSTNAME: &str = "ethereum-sepolia.blockpi.network";
-pub const PUBLICNODE_ETH_MAINNET_HOSTNAME: &str = "ethereum.publicnode.com";
-pub const PUBLICNODE_ETH_SEPOLIA_HOSTNAME: &str = "ethereum-sepolia.publicnode.com";
+pub const PUBLICNODE_ETH_MAINNET_HOSTNAME: &str = "ethereum-rpc.publicnode.com";
+pub const PUBLICNODE_ETH_SEPOLIA_HOSTNAME: &str = "ethereum-sepolia-rpc.publicnode.com";
 pub const ETH_SEPOLIA_HOSTNAME: &str = "rpc.sepolia.org";
 
 // Limited API credentials for local testing.


### PR DESCRIPTION
Public Node recently deprecated the original JSON-RPC URLs. This PR updates the canister to use the new endpoint URLs by default:

* https://ethereum.publicnode.com -> https://ethereum-rpc.publicnode.com
* https://ethereum-sepolia.publicnode.com -> https://ethereum-sepolia-rpc.publicnode.com