### PR TITLE
feat: ability to update chain IDs via `manageProvider` method

### DIFF
--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -93,6 +93,7 @@ type LogEntry = record {
 };
 type ManageProviderArgs = record {
   providerId : nat64;
+  chainId: opt nat64;
   "service" : opt RpcService;
   primary : opt bool;
 };

--- a/providers.did
+++ b/providers.did
@@ -1,0 +1,202 @@
+(
+    vec {
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "cloudflare-eth.com";
+            primary = false;
+            chainId = 1 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 0 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "rpc.ankr.com";
+            primary = false;
+            chainId = 1 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 1 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "ethereum-rpc.publicnode.com";
+            primary = false;
+            chainId = 1 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 2 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "ethereum.blockpi.network";
+            primary = false;
+            chainId = 1 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 3 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "rpc.sepolia.org";
+            primary = false;
+            chainId = 11_155_111 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 4 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "rpc.ankr.com";
+            primary = false;
+            chainId = 11_155_111 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 5 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "ethereum-sepolia.blockpi.network";
+            primary = false;
+            chainId = 11_155_111 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 6 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "ethereum-sepolia-rpc.publicnode.com";
+            primary = false;
+            chainId = 11_155_111 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 7 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "eth-mainnet.g.alchemy.com";
+            primary = false;
+            chainId = 1 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 8 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "eth-sepolia.g.alchemy.com";
+            primary = false;
+            chainId = 11_155_111 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 9 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "arb-mainnet.g.alchemy.com";
+            primary = false;
+            chainId = 42_161 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 10 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "rpc.ankr.com";
+            primary = false;
+            chainId = 42_161 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 11 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "arbitrum.blockpi.network";
+            primary = false;
+            chainId = 42_161 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 12 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "arbitrum-one-rpc.publicnode.com";
+            primary = false;
+            chainId = 42_161 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 13 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "base-mainnet.g.alchemy.com";
+            primary = false;
+            chainId = 42_161 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 14 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "rpc.ankr.com";
+            primary = false;
+            chainId = 42_161 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 15 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "base.blockpi.network";
+            primary = false;
+            chainId = 42_161 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 16 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "base-rpc.publicnode.com";
+            primary = false;
+            chainId = 8_453 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 17 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "opt-mainnet.g.alchemy.com";
+            primary = false;
+            chainId = 10 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 18 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "rpc.ankr.com";
+            primary = false;
+            chainId = 10 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 19 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "optimism.blockpi.network";
+            primary = false;
+            chainId = 10 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 20 : nat64;
+        };
+        record {
+            cyclesPerCall = 0 : nat64;
+            owner = principal "rxqtr-vwnhc-q4tjx-lozjs-u7nxo-2tqsn-cusmy-ip2ke-zy52n-x2ukd-gae";
+            hostname = "optimism-rpc.publicnode.com\n";
+            primary = false;
+            chainId = 10 : nat64;
+            cyclesPerMessageByte = 0 : nat64;
+            providerId = 21 : nat64;
+        };
+    }
+);

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -463,7 +463,7 @@ pub fn do_manage_provider(args: ManageProviderArgs) {
                 if let Some(chain_id) = args.chain_id {
                     log!(
                         INFO,
-                        "Changing provider {:?} to use chain id: {} (original value: {})",
+                        "Updating provider {:?} to use chain id: {} (original value: {})",
                         provider.provider_id,
                         chain_id,
                         provider.chain_id,
@@ -473,7 +473,7 @@ pub fn do_manage_provider(args: ManageProviderArgs) {
                 if let Some(primary) = args.primary {
                     log!(
                         INFO,
-                        "Changing provider {:?} to use primary status: {} (original value: {})",
+                        "Updating provider {:?} to use primary status: {} (original value: {})",
                         provider.provider_id,
                         primary,
                         provider.primary,
@@ -583,7 +583,7 @@ pub async fn do_withdraw_accumulated_cycles(
 pub fn set_service_provider(service: &RpcService, provider: &Provider) {
     log!(
         INFO,
-        "Changing service {:?} to use provider: {}",
+        "Updating service {:?} to use provider: {}",
         service,
         provider.provider_id
     );

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -463,13 +463,21 @@ pub fn do_manage_provider(args: ManageProviderArgs) {
                 if let Some(chain_id) = args.chain_id {
                     log!(
                         INFO,
-                        "Changing provider {:?} to use chain id: {}",
+                        "Changing provider {:?} to use chain id: {} (original value: {})",
                         provider.provider_id,
-                        chain_id
+                        chain_id,
+                        provider.chain_id,
                     );
                     provider.chain_id = chain_id;
                 }
                 if let Some(primary) = args.primary {
+                    log!(
+                        INFO,
+                        "Changing provider {:?} to use primary status: {} (original value: {})",
+                        provider.provider_id,
+                        primary,
+                        provider.primary,
+                    );
                     provider.primary = primary;
                 }
                 if let Some(service) = args.service {

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -460,12 +460,6 @@ pub fn do_manage_provider(args: ManageProviderArgs) {
         let mut providers = providers.borrow_mut();
         match providers.get(&args.provider_id) {
             Some(mut provider) => {
-                if let Some(primary) = args.primary {
-                    provider.primary = primary;
-                }
-                if let Some(service) = args.service {
-                    set_service_provider(&service, &provider);
-                }
                 if let Some(chain_id) = args.chain_id {
                     log!(
                         INFO,
@@ -474,6 +468,12 @@ pub fn do_manage_provider(args: ManageProviderArgs) {
                         chain_id
                     );
                     provider.chain_id = chain_id;
+                }
+                if let Some(primary) = args.primary {
+                    provider.primary = primary;
+                }
+                if let Some(service) = args.service {
+                    set_service_provider(&service, &provider);
                 }
                 providers.insert(args.provider_id, provider);
             }

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -466,6 +466,15 @@ pub fn do_manage_provider(args: ManageProviderArgs) {
                 if let Some(service) = args.service {
                     set_service_provider(&service, &provider);
                 }
+                if let Some(chain_id) = args.chain_id {
+                    log!(
+                        INFO,
+                        "Changing provider {:?} to use chain id: {}",
+                        provider.provider_id,
+                        chain_id
+                    );
+                    provider.chain_id = chain_id;
+                }
                 providers.insert(args.provider_id, provider);
             }
             None => ic_cdk::trap("Provider not found"),

--- a/src/types.rs
+++ b/src/types.rs
@@ -344,6 +344,8 @@ pub struct UpdateProviderArgs {
 pub struct ManageProviderArgs {
     #[serde(rename = "providerId")]
     pub provider_id: u64,
+    #[serde(rename = "chainId")]
+    pub chain_id: Option<u64>,
     pub primary: Option<bool>,
     pub service: Option<RpcService>,
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -941,7 +941,7 @@ fn should_set_provider_chain_id() {
     assert_matches!(
         setup
             .request(
-                RpcService::Chain(after_chain_id),
+                RpcService::Chain(before_chain_id),
                 MOCK_REQUEST_PAYLOAD,
                 MOCK_REQUEST_RESPONSE_BYTES,
             )

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -973,8 +973,7 @@ fn should_set_provider_chain_id() {
             .mock_http(
                 MockOutcallBuilder::new(200, MOCK_REQUEST_RESPONSE).with_url(format!(
                     "https://{}{}",
-                    ALCHEMY_ETH_MAINNET_HOSTNAME,
-                    credential.to_string()
+                    ALCHEMY_ETH_MAINNET_HOSTNAME, credential
                 ))
             )
             .wait(),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -712,6 +712,7 @@ fn should_panic_if_unauthorized_manage_provider() {
     let setup = EvmRpcSetup::new();
     setup.manage_provider(ManageProviderArgs {
         provider_id: 2,
+        chain_id: None,
         primary: Some(true),
         service: None,
     });
@@ -723,6 +724,7 @@ fn should_panic_if_anonymous_manage_provider() {
     let setup = EvmRpcSetup::new().as_anonymous();
     setup.manage_provider(ManageProviderArgs {
         provider_id: 3,
+        chain_id: None,
         primary: Some(true),
         service: None,
     });
@@ -815,6 +817,7 @@ fn should_replace_service_provider() {
         .as_controller()
         .manage_provider(ManageProviderArgs {
             provider_id,
+            chain_id: None,
             primary: Some(true),
             service: Some(RpcService::EthMainnet(EthMainnetService::Ankr)),
         });
@@ -885,6 +888,7 @@ fn should_set_primary_provider() {
         .as_controller()
         .manage_provider(ManageProviderArgs {
             provider_id,
+            chain_id: None,
             primary: Some(true),
             service: None,
         });
@@ -899,6 +903,78 @@ fn should_set_primary_provider() {
                 MockOutcallBuilder::new(200, MOCK_REQUEST_RESPONSE).with_url(format!(
                     "https://{}{}",
                     ALCHEMY_ETH_MAINNET_HOSTNAME, after_credential
+                ))
+            )
+            .wait(),
+        Ok(_)
+    );
+}
+
+#[test]
+fn should_set_provider_chain_id() {
+    let setup = EvmRpcSetup::new().authorize_caller(Auth::FreeRpc);
+    let before_chain_id = 12345;
+    let after_chain_id = 56789;
+    let credential = "/credential";
+    setup
+        .clone()
+        .authorize_caller(Auth::RegisterProvider)
+        .register_provider(RegisterProviderArgs {
+            chain_id: before_chain_id,
+            hostname: ALCHEMY_ETH_MAINNET_HOSTNAME.to_string(),
+            credential_path: credential.to_string(),
+            credential_headers: None,
+            cycles_per_call: 0,
+            cycles_per_message_byte: 0,
+        });
+    let provider_id = setup
+        .clone()
+        .authorize_caller(Auth::RegisterProvider)
+        .register_provider(RegisterProviderArgs {
+            chain_id: before_chain_id,
+            hostname: ALCHEMY_ETH_MAINNET_HOSTNAME.to_string(),
+            credential_path: credential.to_string(),
+            credential_headers: None,
+            cycles_per_call: 0,
+            cycles_per_message_byte: 0,
+        });
+    assert_matches!(
+        setup
+            .request(
+                RpcService::Chain(after_chain_id),
+                MOCK_REQUEST_PAYLOAD,
+                MOCK_REQUEST_RESPONSE_BYTES,
+            )
+            .mock_http(
+                MockOutcallBuilder::new(200, MOCK_REQUEST_RESPONSE).with_url(format!(
+                    "https://{}{}",
+                    ALCHEMY_ETH_MAINNET_HOSTNAME, credential
+                ))
+            )
+            .wait(),
+        Ok(_)
+    );
+    setup
+        .clone()
+        .as_controller()
+        .manage_provider(ManageProviderArgs {
+            provider_id,
+            chain_id: Some(after_chain_id),
+            primary: None,
+            service: None,
+        });
+    assert_matches!(
+        setup
+            .request(
+                RpcService::Chain(after_chain_id),
+                MOCK_REQUEST_PAYLOAD,
+                MOCK_REQUEST_RESPONSE_BYTES,
+            )
+            .mock_http(
+                MockOutcallBuilder::new(200, MOCK_REQUEST_RESPONSE).with_url(format!(
+                    "https://{}{}",
+                    ALCHEMY_ETH_MAINNET_HOSTNAME,
+                    credential.to_string()
                 ))
             )
             .wait(),


### PR DESCRIPTION
This change makes it possible for principals with the `Manage` permission to modify previously registered chain IDs.
