### PR TITLE
dfx: add default canister init args

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Add the following to your `dfx.json` config file (replace the `ic` principal wit
         "id": {
           "ic": "7hfb6-caaaa-aaaar-qadga-cai"
         }
-      }
+      },
+      "init_arg": "(record { nodesInSubnet = 28 })"
     }
   }
 }
@@ -58,7 +59,7 @@ The EVM RPC canister also supports [`dfx deps pull`](https://internetcomputer.or
   "canisters": {
     "evm_rpc": {
       "type": "pull",
-      "id": "7hfb6-caaaa-aaaar-qadga-cai",
+      "id": "7hfb6-caaaa-aaaar-qadga-cai"
     }
   }
 }

--- a/dfx.json
+++ b/dfx.json
@@ -14,19 +14,22 @@
         "wasm_url": "https://github.com/internet-computer-protocol/evm-rpc-canister/releases/latest/download/evm_rpc.wasm.gz",
         "init_guide": "Number of nodes in the subnet, e.g. '(record {nodesInSubnet = 28})'"
       },
-      "gzip": true
+      "gzip": true,
+      "init_arg": "(record {nodesInSubnet = 28})"
     },
     "evm_rpc_staging_13_node": {
       "candid": "candid/evm_rpc.did",
       "type": "rust",
       "package": "evm_rpc",
-      "gzip": true
+      "gzip": true,
+      "init_arg": "(record {nodesInSubnet = 13})"
     },
     "evm_rpc_staging_fiduciary": {
       "candid": "candid/evm_rpc.did",
       "type": "rust",
       "package": "evm_rpc",
-      "gzip": true
+      "gzip": true,
+      "init_arg": "(record {nodesInSubnet = 28})"
     },
     "e2e_rust": {
       "dependencies": ["evm_rpc_staging_fiduciary"],


### PR DESCRIPTION
This PR simplifies local development via the new `init_arg` field in the project's `dfx.json` file.