### PR TITLE
feat!: reduce mutability of RPC providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "synstructure 0.12.6",
+ "synstructure",
 ]
 
 [[package]]
@@ -4369,124 +4369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.60",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4494,14 +4376,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
- "icu_normalizer",
- "icu_properties",
- "smallvec",
- "utf8_iter",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -4768,12 +4648,6 @@ name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
-
-[[package]]
-name = "litemap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "lock_api"
@@ -6975,17 +6849,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.60",
-]
-
-[[package]]
 name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7165,16 +7028,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec",
 ]
 
 [[package]]
@@ -7528,10 +7381,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -7565,9 +7433,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -7576,22 +7444,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -8144,18 +8000,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
 name = "wsl"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8231,30 +8075,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "yoke"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.60",
- "synstructure 0.13.1",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8275,27 +8095,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.60",
- "synstructure 0.13.1",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8309,28 +8108,6 @@ name = "zeroize_derive"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.60",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -95,7 +95,6 @@ type LogEntry = record {
 };
 type ManageProviderArgs = record {
   providerId : nat64;
-  chainId: opt nat64;
   "service" : opt RpcService;
   primary : opt bool;
 };

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -233,15 +233,6 @@ type TransactionReceipt = record {
   contractAddress : opt text;
   gasUsed : nat;
 };
-type UpdateProviderArgs = record {
-  cyclesPerCall : opt nat64;
-  credentialPath : opt text;
-  hostname : opt text;
-  credentialHeaders : opt vec HttpHeader;
-  primary : opt bool;
-  cyclesPerMessageByte : opt nat64;
-  providerId : nat64;
-};
 type ValidationError = variant {
   Custom : text;
   HostNotAllowed : text;
@@ -273,7 +264,5 @@ service : (InitArgs) -> {
   request : (RpcService, json : text, maxResponseBytes : nat64) -> (RequestResult);
   requestCost : (RpcService, json : text, maxResponseBytes : nat64) -> (RequestCostResult) query;
   setOpenRpcAccess : (active : bool) -> ();
-  unregisterProvider : (ProviderId) -> (bool);
-  updateProvider : (UpdateProviderArgs) -> ();
   withdrawAccumulatedCycles : (ProviderId, recipient : principal) -> ();
 };

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -22,6 +22,8 @@ pub const COLLATERAL_CYCLES_PER_NODE: u128 = 10_000_000;
 // Minimum number of bytes charged for a URL; improves consistency of costs between providers
 pub const RPC_URL_MIN_COST_BYTES: u32 = 256;
 
+pub const MAXIMUM_PROVIDER_COUNT: usize = 10_000;
+
 pub const MINIMUM_WITHDRAWAL_CYCLES: u128 = 1_000_000_000;
 
 pub const STRING_STORABLE_MAX_SIZE: u32 = 100;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -22,7 +22,7 @@ pub const COLLATERAL_CYCLES_PER_NODE: u128 = 10_000_000;
 // Minimum number of bytes charged for a URL; improves consistency of costs between providers
 pub const RPC_URL_MIN_COST_BYTES: u32 = 256;
 
-pub const MAXIMUM_PROVIDER_COUNT: usize = 10_000;
+pub const MAXIMUM_PROVIDER_COUNT: u64 = 10_000;
 
 pub const MINIMUM_WITHDRAWAL_CYCLES: u128 = 1_000_000_000;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,16 +24,14 @@ use ic_cdk::{query, update};
 use ic_nervous_system_common::serve_metrics;
 
 use evm_rpc::{
-    auth::{do_authorize, do_deauthorize, require_manage_or_controller, require_register_provider},
+    auth::{do_authorize, do_deauthorize},
     constants::WASM_PAGE_SIZE,
     http::{do_json_rpc_request, do_transform_http_request},
     memory::{AUTH, METADATA, PROVIDERS, SERVICE_PROVIDER_MAP, UNSTABLE_METRICS},
-    providers::{
-        do_manage_provider, do_register_provider, do_unregister_provider, do_update_provider,
-    },
+    providers::{do_manage_provider, do_register_provider},
     types::{
         candid_types, Auth, InitArgs, ManageProviderArgs, MetricRpcMethod, Metrics, MultiRpcResult,
-        ProviderView, RegisterProviderArgs, RpcServices, UpdateProviderArgs,
+        ProviderView, RegisterProviderArgs, RpcServices,
     },
 };
 
@@ -166,20 +164,6 @@ fn get_providers() -> Vec<ProviderView> {
 #[candid_method(rename = "registerProvider")]
 fn register_provider(provider: RegisterProviderArgs) -> u64 {
     do_register_provider(ic_cdk::caller(), provider)
-}
-
-#[update(name = "unregisterProvider")]
-#[candid_method(rename = "unregisterProvider")]
-fn unregister_provider(provider_id: u64) -> bool {
-    let caller = ic_cdk::caller();
-    do_unregister_provider(caller, is_controller(&caller), provider_id)
-}
-
-#[update(name = "updateProvider")]
-#[candid_method(rename = "updateProvider")]
-fn update_provider(provider: UpdateProviderArgs) {
-    let caller = ic_cdk::caller();
-    do_update_provider(caller, is_controller(&caller), provider)
 }
 
 #[update(name = "manageProvider", guard = "require_manage_or_controller")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use cketh_common::eth_rpc_client::providers::RpcService;
 use cketh_common::eth_rpc_client::RpcConfig;
 use cketh_common::logs::INFO;
 use evm_rpc::accounting::{get_cost_with_collateral, get_rpc_cost};
+use evm_rpc::auth::{require_manage_or_controller, require_register_provider};
 use evm_rpc::candid_rpc::CandidRpcClient;
 use evm_rpc::http::get_http_response_body;
 use evm_rpc::memory::{get_nodes_in_subnet, set_nodes_in_subnet};

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -10,15 +10,14 @@ use ic_canister_log::log;
 
 use crate::{
     add_metric,
-    auth::do_deauthorize,
     constants::{
         ARBITRUM_ONE_CHAIN_ID, BASE_MAINNET_CHAIN_ID, ETH_MAINNET_CHAIN_ID, ETH_SEPOLIA_CHAIN_ID,
         MINIMUM_WITHDRAWAL_CYCLES, OPTIMISM_MAINNET_CHAIN_ID,
     },
     memory::{METADATA, PROVIDERS, SERVICE_PROVIDER_MAP},
     types::{
-        Auth, ManageProviderArgs, Provider, RegisterProviderArgs, ResolvedRpcService,
-        StorableRpcService, UpdateProviderArgs,
+        ManageProviderArgs, Provider, RegisterProviderArgs, ResolvedRpcService, StorableRpcService,
+        UpdateProviderArgs,
     },
     validate::{validate_credential_headers, validate_credential_path, validate_hostname},
 };
@@ -427,7 +426,6 @@ pub fn do_register_provider(caller: Principal, args: RegisterProviderArgs) -> u6
         m.borrow_mut().set(metadata).unwrap();
         id
     });
-    do_deauthorize(caller, Auth::RegisterProvider);
     log!(INFO, "[{}] Registering provider: {:?}", caller, provider_id);
     PROVIDERS.with(|providers| {
         providers.borrow_mut().insert(

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -45,7 +45,6 @@ pub const LLAMA_BASE_MAINNET_HOSTNAME: &str = "base.llamarpc.com";
 pub const LLAMA_OPTIMISM_MAINNET_HOSTNAME: &str = "optimism.llamarpc.com";
 
 // Limited API credentials for local testing.
-// Use `dfx canister call evm_rpc updateProvider ...` to pass your own keys.
 pub const ALCHEMY_ETH_MAINNET_CREDENTIAL: &str = "/v2/zBxaSBUMfuH8XnA-uLIWeXfCx1T8ItkM";
 pub const ALCHEMY_ETH_SEPOLIA_CREDENTIAL: &str = "/v2/Mbow19DWsfPXiTpdgvRu4HQq63iYycU-";
 pub const ALCHEMY_ARBITRUM_ONE_CREDENTIAL: &str = "/v2";

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -510,16 +510,6 @@ pub fn do_manage_provider(args: ManageProviderArgs) {
         let mut providers = providers.borrow_mut();
         match providers.get(&args.provider_id) {
             Some(mut provider) => {
-                if let Some(chain_id) = args.chain_id {
-                    log!(
-                        INFO,
-                        "Updating provider {:?} to use chain id: {} (original value: {})",
-                        provider.provider_id,
-                        chain_id,
-                        provider.chain_id,
-                    );
-                    provider.chain_id = chain_id;
-                }
                 if let Some(primary) = args.primary {
                     log!(
                         INFO,

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -12,7 +12,7 @@ use crate::{
     add_metric,
     constants::{
         ARBITRUM_ONE_CHAIN_ID, BASE_MAINNET_CHAIN_ID, ETH_MAINNET_CHAIN_ID, ETH_SEPOLIA_CHAIN_ID,
-        MINIMUM_WITHDRAWAL_CYCLES, OPTIMISM_MAINNET_CHAIN_ID,
+        MAXIMUM_PROVIDER_COUNT, MINIMUM_WITHDRAWAL_CYCLES, OPTIMISM_MAINNET_CHAIN_ID,
     },
     memory::{METADATA, PROVIDERS, SERVICE_PROVIDER_MAP},
     types::{
@@ -427,8 +427,12 @@ pub fn do_register_provider(caller: Principal, args: RegisterProviderArgs) -> u6
         id
     });
     log!(INFO, "[{}] Registering provider: {:?}", caller, provider_id);
-    PROVIDERS.with(|providers| {
-        providers.borrow_mut().insert(
+    PROVIDERS.with_borrow_mut(|providers| {
+        assert!(
+            providers.len() <= MAXIMUM_PROVIDER_COUNT,
+            "Too many providers"
+        );
+        providers.insert(
             provider_id,
             Provider {
                 provider_id,

--- a/src/types.rs
+++ b/src/types.rs
@@ -325,21 +325,6 @@ pub struct RegisterProviderArgs {
     pub cycles_per_message_byte: u64,
 }
 
-#[derive(Clone, CandidType, Deserialize)]
-pub struct UpdateProviderArgs {
-    #[serde(rename = "providerId")]
-    pub provider_id: u64,
-    pub hostname: Option<String>,
-    #[serde(rename = "credentialPath")]
-    pub credential_path: Option<String>,
-    #[serde(rename = "credentialHeaders")]
-    pub credential_headers: Option<Vec<HttpHeader>>,
-    #[serde(rename = "cyclesPerCall")]
-    pub cycles_per_call: Option<u64>,
-    #[serde(rename = "cyclesPerMessageByte")]
-    pub cycles_per_message_byte: Option<u64>,
-}
-
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct ManageProviderArgs {
     #[serde(rename = "providerId")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -344,8 +344,6 @@ pub struct UpdateProviderArgs {
 pub struct ManageProviderArgs {
     #[serde(rename = "providerId")]
     pub provider_id: u64,
-    #[serde(rename = "chainId")]
-    pub chain_id: Option<u64>,
     pub primary: Option<bool>,
     pub service: Option<RpcService>,
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -686,7 +686,6 @@ fn should_panic_if_unauthorized_manage_provider() {
     let setup = EvmRpcSetup::new();
     setup.manage_provider(ManageProviderArgs {
         provider_id: 2,
-        chain_id: None,
         primary: Some(true),
         service: None,
     });
@@ -698,7 +697,6 @@ fn should_panic_if_anonymous_manage_provider() {
     let setup = EvmRpcSetup::new().as_anonymous();
     setup.manage_provider(ManageProviderArgs {
         provider_id: 3,
-        chain_id: None,
         primary: Some(true),
         service: None,
     });
@@ -722,7 +720,6 @@ fn should_replace_service_provider() {
         .as_controller()
         .manage_provider(ManageProviderArgs {
             provider_id,
-            chain_id: None,
             primary: Some(true),
             service: Some(RpcService::EthMainnet(EthMainnetService::Ankr)),
         });
@@ -793,7 +790,6 @@ fn should_set_primary_provider() {
         .as_controller()
         .manage_provider(ManageProviderArgs {
             provider_id,
-            chain_id: None,
             primary: Some(true),
             service: None,
         });
@@ -808,77 +804,6 @@ fn should_set_primary_provider() {
                 MockOutcallBuilder::new(200, MOCK_REQUEST_RESPONSE).with_url(format!(
                     "https://{}{}",
                     ALCHEMY_ETH_MAINNET_HOSTNAME, after_credential
-                ))
-            )
-            .wait(),
-        Ok(_)
-    );
-}
-
-#[test]
-fn should_set_provider_chain_id() {
-    let setup = EvmRpcSetup::new().authorize_caller(Auth::FreeRpc);
-    let before_chain_id = 12345;
-    let after_chain_id = 56789;
-    let credential = "/credential";
-    setup
-        .clone()
-        .authorize_caller(Auth::RegisterProvider)
-        .register_provider(RegisterProviderArgs {
-            chain_id: before_chain_id,
-            hostname: ALCHEMY_ETH_MAINNET_HOSTNAME.to_string(),
-            credential_path: credential.to_string(),
-            credential_headers: None,
-            cycles_per_call: 0,
-            cycles_per_message_byte: 0,
-        });
-    let provider_id = setup
-        .clone()
-        .authorize_caller(Auth::RegisterProvider)
-        .register_provider(RegisterProviderArgs {
-            chain_id: before_chain_id,
-            hostname: ALCHEMY_ETH_MAINNET_HOSTNAME.to_string(),
-            credential_path: credential.to_string(),
-            credential_headers: None,
-            cycles_per_call: 0,
-            cycles_per_message_byte: 0,
-        });
-    assert_matches!(
-        setup
-            .request(
-                RpcService::Chain(before_chain_id),
-                MOCK_REQUEST_PAYLOAD,
-                MOCK_REQUEST_RESPONSE_BYTES,
-            )
-            .mock_http(
-                MockOutcallBuilder::new(200, MOCK_REQUEST_RESPONSE).with_url(format!(
-                    "https://{}{}",
-                    ALCHEMY_ETH_MAINNET_HOSTNAME, credential
-                ))
-            )
-            .wait(),
-        Ok(_)
-    );
-    setup
-        .clone()
-        .as_controller()
-        .manage_provider(ManageProviderArgs {
-            provider_id,
-            chain_id: Some(after_chain_id),
-            primary: None,
-            service: None,
-        });
-    assert_matches!(
-        setup
-            .request(
-                RpcService::Chain(after_chain_id),
-                MOCK_REQUEST_PAYLOAD,
-                MOCK_REQUEST_RESPONSE_BYTES,
-            )
-            .mock_http(
-                MockOutcallBuilder::new(200, MOCK_REQUEST_RESPONSE).with_url(format!(
-                    "https://{}{}",
-                    ALCHEMY_ETH_MAINNET_HOSTNAME, credential
                 ))
             )
             .wait(),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -603,13 +603,6 @@ fn should_register_provider() {
         cycles_per_call: 0,
         cycles_per_message_byte: 0,
     });
-    // Permission removed after registering
-    assert!(setup
-        .clone()
-        .as_controller()
-        .get_authorized(Auth::RegisterProvider)
-        .into_iter()
-        .all(|p| p != setup.caller.0));
     // Permission must be granted for each additional provider
     setup = setup.authorize_caller(Auth::RegisterProvider);
     let b_id = setup.register_provider(RegisterProviderArgs {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -41,7 +41,7 @@ use evm_rpc::{
     },
     types::{
         candid_types, Auth, InitArgs, ManageProviderArgs, Metrics, MultiRpcResult, ProviderView,
-        RegisterProviderArgs, RpcMethod, RpcResult, RpcServices, UpdateProviderArgs,
+        RegisterProviderArgs, RpcMethod, RpcResult, RpcServices,
     },
 };
 use mock::{MockOutcall, MockOutcallBuilder};


### PR DESCRIPTION
This PR adjusts the canister to only allow principals with the `Manage` permission to change the `primary` status (to specify the recommended providers for a specific chain) and `service` mapping (such as pointing `#EthMainnet(#Ankr)` to a new provider ID). Everything else is now immutable aside from changes specified in NNS proposals. I also removed the `unregisterProvider` method.