### PR TITLE
auth: allow any principal to call `getAuthorized`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -361,7 +361,7 @@ fn authorize(principal: Principal, auth: Auth) -> bool {
     do_authorize(principal, auth)
 }
 
-#[query(name = "getAuthorized", guard = "require_manage_or_controller")]
+#[query(name = "getAuthorized")]
 #[candid_method(query, rename = "getAuthorized")]
 fn get_authorized(auth: Auth) -> Vec<Principal> {
     AUTH.with(|a| {


### PR DESCRIPTION
This PR increases visibility of principals with internal authorizations for transparency. 