### PR TITLE
ci: bump `setup-protoc` action to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@v3
 
       - run: rustup component add clippy
 
@@ -40,7 +40,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@v3
 
       - name: Cargo test
         run: unset CI && cargo test


### PR DESCRIPTION
Addresses a CI warning by updating the `setup-protoc` action.

Depends on #227 (merging will fix the error in this PR).