### PR TITLE
candid: remove hostname from `UpdateProviderArgs`

### DIFF
--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -95,7 +95,7 @@ type LogEntry = record {
 };
 type ManageProviderArgs = record {
   providerId : nat64;
-  chainId : opt nat64;
+  chainId: opt nat64;
   "service" : opt RpcService;
   primary : opt bool;
 };
@@ -235,8 +235,10 @@ type TransactionReceipt = record {
 };
 type UpdateProviderArgs = record {
   providerId : nat64;
+  cyclesPerCall : opt nat64;
   credentialPath : opt text;
   credentialHeaders : opt vec HttpHeader;
+  cyclesPerMessageByte : opt nat64;
 };
 type ValidationError = variant {
   Custom : text;

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -95,7 +95,7 @@ type LogEntry = record {
 };
 type ManageProviderArgs = record {
   providerId : nat64;
-  chainId: opt nat64;
+  chainId : opt nat64;
   "service" : opt RpcService;
   primary : opt bool;
 };
@@ -234,13 +234,9 @@ type TransactionReceipt = record {
   gasUsed : nat;
 };
 type UpdateProviderArgs = record {
-  cyclesPerCall : opt nat64;
-  credentialPath : opt text;
-  hostname : opt text;
-  credentialHeaders : opt vec HttpHeader;
-  primary : opt bool;
-  cyclesPerMessageByte : opt nat64;
   providerId : nat64;
+  credentialPath : opt text;
+  credentialHeaders : opt vec HttpHeader;
 };
 type ValidationError = variant {
   Custom : text;

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -486,6 +486,12 @@ pub fn do_update_provider(caller: Principal, is_controller: bool, args: UpdatePr
                         validate_credential_headers(&headers).unwrap();
                         provider.credential_headers = headers;
                     }
+                    if let Some(cycles_per_call) = args.cycles_per_call {
+                        provider.cycles_per_call = cycles_per_call;
+                    }
+                    if let Some(cycles_per_message_byte) = args.cycles_per_message_byte {
+                        provider.cycles_per_message_byte = cycles_per_message_byte;
+                    }
                     providers.insert(args.provider_id, provider);
                 } else {
                     ic_cdk::trap("You are not authorized: check provider owner");

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -478,10 +478,6 @@ pub fn do_update_provider(caller: Principal, is_controller: bool, args: UpdatePr
             Some(mut provider) => {
                 if provider.owner == caller || is_controller {
                     log!(INFO, "[{}] Updating provider: {}", caller, args.provider_id);
-                    if let Some(hostname) = args.hostname {
-                        validate_hostname(&hostname).unwrap();
-                        provider.hostname = hostname;
-                    }
                     if let Some(path) = args.credential_path {
                         validate_credential_path(&path).unwrap();
                         provider.credential_path = path;
@@ -489,12 +485,6 @@ pub fn do_update_provider(caller: Principal, is_controller: bool, args: UpdatePr
                     if let Some(headers) = args.credential_headers {
                         validate_credential_headers(&headers).unwrap();
                         provider.credential_headers = headers;
-                    }
-                    if let Some(cycles_per_call) = args.cycles_per_call {
-                        provider.cycles_per_call = cycles_per_call;
-                    }
-                    if let Some(cycles_per_message_byte) = args.cycles_per_message_byte {
-                        provider.cycles_per_message_byte = cycles_per_message_byte;
                     }
                     providers.insert(args.provider_id, provider);
                 } else {

--- a/src/types.rs
+++ b/src/types.rs
@@ -333,6 +333,10 @@ pub struct UpdateProviderArgs {
     pub credential_path: Option<String>,
     #[serde(rename = "credentialHeaders")]
     pub credential_headers: Option<Vec<HttpHeader>>,
+    #[serde(rename = "cyclesPerCall")]
+    pub cycles_per_call: Option<u64>,
+    #[serde(rename = "cyclesPerMessageByte")]
+    pub cycles_per_message_byte: Option<u64>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -329,15 +329,10 @@ pub struct RegisterProviderArgs {
 pub struct UpdateProviderArgs {
     #[serde(rename = "providerId")]
     pub provider_id: u64,
-    pub hostname: Option<String>,
     #[serde(rename = "credentialPath")]
     pub credential_path: Option<String>,
     #[serde(rename = "credentialHeaders")]
     pub credential_headers: Option<Vec<HttpHeader>>,
-    #[serde(rename = "cyclesPerCall")]
-    pub cycles_per_call: Option<u64>,
-    #[serde(rename = "cyclesPerMessageByte")]
-    pub cycles_per_message_byte: Option<u64>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -684,11 +684,8 @@ fn should_panic_if_anonymous_update_provider() {
     let setup = EvmRpcSetup::new().as_anonymous();
     setup.update_provider(UpdateProviderArgs {
         provider_id: 3,
-        hostname: Some("unauthorized.host".to_string()),
         credential_path: None,
         credential_headers: None,
-        cycles_per_call: None,
-        cycles_per_message_byte: None,
     });
 }
 
@@ -737,11 +734,8 @@ fn should_panic_if_unauthorized_update_provider() {
     let setup = EvmRpcSetup::new();
     setup.update_provider(UpdateProviderArgs {
         provider_id: 0,
-        hostname: Some("unauthorized.host".to_string()),
         credential_path: None,
         credential_headers: None,
-        cycles_per_call: None,
-        cycles_per_message_byte: None,
     });
 }
 
@@ -750,11 +744,8 @@ fn should_allow_controller_update_provider() {
     let setup = EvmRpcSetup::new().as_controller();
     setup.update_provider(UpdateProviderArgs {
         provider_id: 0,
-        hostname: Some("controller.host".to_string()),
         credential_path: None,
         credential_headers: None,
-        cycles_per_call: None,
-        cycles_per_message_byte: None,
     });
 }
 
@@ -776,11 +767,8 @@ fn should_panic_if_manage_auth_update_non_owned_provider() {
         });
     setup.update_provider(UpdateProviderArgs {
         provider_id,
-        hostname: Some("unauthorized.host".to_string()),
         credential_path: None,
         credential_headers: None,
-        cycles_per_call: None,
-        cycles_per_message_byte: None,
     });
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -686,6 +686,8 @@ fn should_panic_if_anonymous_update_provider() {
         provider_id: 3,
         credential_path: None,
         credential_headers: None,
+        cycles_per_call: None,
+        cycles_per_message_byte: None,
     });
 }
 
@@ -736,6 +738,8 @@ fn should_panic_if_unauthorized_update_provider() {
         provider_id: 0,
         credential_path: None,
         credential_headers: None,
+        cycles_per_call: None,
+        cycles_per_message_byte: None,
     });
 }
 
@@ -746,6 +750,8 @@ fn should_allow_controller_update_provider() {
         provider_id: 0,
         credential_path: None,
         credential_headers: None,
+        cycles_per_call: None,
+        cycles_per_message_byte: None,
     });
 }
 
@@ -769,6 +775,8 @@ fn should_panic_if_manage_auth_update_non_owned_provider() {
         provider_id,
         credential_path: None,
         credential_headers: None,
+        cycles_per_call: None,
+        cycles_per_message_byte: None,
     });
 }
 


### PR DESCRIPTION
This is a simplified iteration on #224 to reduce the immutability of RPC providers. 

The only change is the removal of the ability to modify the hostname and cycles costs of existing providers. 