### PR TITLE
ci: skip checking Llama + Base mainnet provider

### DIFF
--- a/e2e/motoko/main.mo
+++ b/e2e/motoko/main.mo
@@ -32,6 +32,7 @@ shared ({ caller = installer }) actor class Main() {
         (#EthMainnet(#BlockPi), "eth_sendRawTransaction"), // "Private transaction replacement (same nonce) with gas price change lower than 10% is not allowed within 30 sec from the previous transaction."
         (#EthMainnet(#Llama), "eth_sendRawTransaction"), // Non-standard error message
         (#ArbitrumOne(#Ankr), "eth_getLogs"), // "Timeout expired"
+
         (#BaseMainnet(#Llama), "eth_getBlockByNumber"), // "no response"
         (#BaseMainnet(#Llama), "eth_getLogs"), // "no response"
         (#BaseMainnet(#Llama), "eth_getTransactionReceipt"), // "no response"

--- a/e2e/motoko/main.mo
+++ b/e2e/motoko/main.mo
@@ -31,7 +31,12 @@ shared ({ caller = installer }) actor class Main() {
     let ignoredTests = [
         (#EthMainnet(#BlockPi), "eth_sendRawTransaction"), // "Private transaction replacement (same nonce) with gas price change lower than 10% is not allowed within 30 sec from the previous transaction."
         (#EthMainnet(#Llama), "eth_sendRawTransaction"), // Non-standard error message
-        (#ArbitrumOne(#Ankr), "eth_getLogs"), // Timeout expired
+        (#ArbitrumOne(#Ankr), "eth_getLogs"), // "Timeout expired"
+        (#BaseMainnet(#Llama), "eth_getBlockByNumber"), // "no response"
+        (#BaseMainnet(#Llama), "eth_getLogs"), // "no response"
+        (#BaseMainnet(#Llama), "eth_getTransactionReceipt"), // "no response"
+        (#BaseMainnet(#Llama), "eth_getTransactionCount"), // "no response"
+        (#BaseMainnet(#Llama), "eth_feeHistory"), // "no response"
     ];
 
     func runTests(caller : Principal, category : TestCategory) : async () {


### PR DESCRIPTION
Skips CI checking the combination of LlamaNodes RPC service + Base mainnet chain due to a recent, seemingly temporary "no response" error message. 