### PR TITLE
feat!: simplify `eth_feeHistory` result type

### DIFF
--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -166,7 +166,7 @@ type RejectionCode = variant {
   SysFatal;
   CanisterReject;
 };
-type FeeHistoryResult = variant { Ok : opt FeeHistory; Err : RpcError };
+type FeeHistoryResult = variant { Ok : FeeHistory; Err : RpcError };
 type GetBlockByNumberResult = variant { Ok : Block; Err : RpcError };
 type GetLogsResult = variant { Ok : vec LogEntry; Err : RpcError };
 type GetTransactionCountResult = variant { Ok : nat; Err : RpcError };

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -249,12 +249,12 @@ impl CandidRpcClient {
     pub async fn eth_fee_history(
         &self,
         args: candid_types::FeeHistoryArgs,
-    ) -> MultiRpcResult<Option<FeeHistory>> {
+    ) -> MultiRpcResult<FeeHistory> {
         process_result(
             RpcMethod::EthFeeHistory,
             self.client.eth_fee_history(args.into()).await,
         )
-        .map(|history| history.into())
+        .map(|history| history)
     }
 
     pub async fn eth_send_raw_transaction(

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ pub async fn eth_fee_history(
     source: RpcServices,
     config: Option<RpcConfig>,
     args: candid_types::FeeHistoryArgs,
-) -> MultiRpcResult<Option<FeeHistory>> {
+) -> MultiRpcResult<FeeHistory> {
     match CandidRpcClient::new(source, config) {
         Ok(source) => source.eth_fee_history(args).await,
         Err(err) => Err(err).into(),


### PR DESCRIPTION
Replaces `opt FeeHistory` with `FeeHistory` based on the [Ethereum JSON-RPC spec](https://ethereum.github.io/execution-apis/api-documentation/).