### PR TITLE
feat: `evm_rpc_types` crate and `Nat256`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 target/
 .dfx/
 .mops/
+.idea/
 
 *.generated.did
 *.wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,6 +1613,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "evm_rpc_types"
+version = "0.1.0"
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
  "build-info-common",
  "chrono",
  "format-buf",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
  "proc-macro-error",
  "proc-macro-hack",
@@ -683,7 +683,7 @@ dependencies = [
  "lalrpop-util",
  "leb128",
  "logos",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
  "num_enum 0.6.1",
  "paste",
@@ -1216,7 +1216,7 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
  "rusticata-macros",
 ]
@@ -1451,7 +1451,7 @@ version = "3.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
 dependencies = [
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1587,6 +1587,7 @@ dependencies = [
  "async-trait",
  "candid",
  "ethers-core",
+ "evm_rpc_types",
  "getrandom 0.2.14",
  "hex",
  "ic-base-types 0.8.0",
@@ -1617,6 +1618,8 @@ name = "evm_rpc_types"
 version = "0.1.0"
 dependencies = [
  "candid",
+ "num-bigint 0.4.6",
+ "proptest",
  "serde",
 ]
 
@@ -2572,7 +2575,7 @@ dependencies = [
  "icrc-ledger-types 0.1.4",
  "minicbor",
  "minicbor-derive",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
  "phantom_newtype 0.9.0",
  "rlp",
@@ -2673,7 +2676,7 @@ source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e505
 dependencies = [
  "k256",
  "lazy_static",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "pem 1.1.1",
  "rand",
  "simple_asn1",
@@ -2687,7 +2690,7 @@ source = "git+https://github.com/dfinity/ic?rev=5991b07d0e396b7885d5b4d4c917f729
 dependencies = [
  "k256",
  "lazy_static",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "pem 1.1.1",
  "rand",
  "simple_asn1",
@@ -2701,7 +2704,7 @@ source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e505
 dependencies = [
  "ic-crypto-getrandom-for-wasm",
  "lazy_static",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "p256",
  "pem 1.1.1",
  "rand",
@@ -2853,7 +2856,7 @@ dependencies = [
  "ic-crypto-internal-basic-sig-der-utils",
  "ic-crypto-sha2 0.8.0",
  "ic-types",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
  "pkcs8",
  "rsa",
@@ -3507,7 +3510,7 @@ dependencies = [
  "ic-ledger-core",
  "ic-ledger-hash-of",
  "icrc-ledger-types 0.1.2",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
  "serde",
  "serde_bytes",
@@ -4369,7 +4372,7 @@ dependencies = [
  "candid",
  "crc32fast",
  "hex",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
  "serde",
  "serde_bytes",
@@ -4941,7 +4944,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -4962,9 +4965,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -5053,7 +5056,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -5713,10 +5716,12 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
+ "bit-set",
+ "bit-vec 0.6.3",
  "bitflags 2.5.0",
  "lazy_static",
  "num-traits",
@@ -5724,6 +5729,8 @@ dependencies = [
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax 0.8.3",
+ "rusty-fork",
+ "tempfile",
  "unarray",
 ]
 
@@ -5838,6 +5845,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -6259,6 +6272,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6518,7 +6543,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
  "thiserror",
  "time",
@@ -7479,6 +7504,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,6 +1615,10 @@ dependencies = [
 [[package]]
 name = "evm_rpc_types"
 version = "0.1.0"
+dependencies = [
+ "candid",
+ "serde",
+]
 
 [[package]]
 name = "fallible-iterator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ inherits = "release"
 
 [dependencies]
 candid = { workspace = true }
+evm_rpc_types = { path = "evm_rpc_types" }
 getrandom = { workspace = true }
 ic-canisters-http-types = { workspace = true }
 ic-nervous-system-common = { workspace = true }
@@ -58,8 +59,11 @@ ic-certified-map = "0.4"
 ic-cdk = "0.10"
 ic-cdk-macros = "0.7"
 ic-cdk-bindgen = "0.1"
+num-bigint = "0.4.6"
+proptest = "1.5.0"
 serde = "1.0"
 serde_json = "1.0"
+
 
 [patch.crates-io]
 wasm-bindgen = { git = "https://github.com/dfinity/wasm-bindgen", rev = "9cde9c9a88c1fad13a8663277650e01b5671843e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ maplit = "1.0"
 num = "0.4"
 num-traits = "0.2"
 num-derive = "0.4"
-serde = "1.0"
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 url = "2.5"
 async-trait = "0.1"
 hex = "0.4"
@@ -58,6 +58,8 @@ ic-certified-map = "0.4"
 ic-cdk = "0.10"
 ic-cdk-macros = "0.7"
 ic-cdk-bindgen = "0.1"
+serde = "1.0"
+serde_json = "1.0"
 
 [patch.crates-io]
 wasm-bindgen = { git = "https://github.com/dfinity/wasm-bindgen", rev = "9cde9c9a88c1fad13a8663277650e01b5671843e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,4 +63,4 @@ ic-cdk-bindgen = "0.1"
 wasm-bindgen = { git = "https://github.com/dfinity/wasm-bindgen", rev = "9cde9c9a88c1fad13a8663277650e01b5671843e" }
 
 [workspace]
-members = ["e2e/rust"]
+members = ["e2e/rust", "evm_rpc_types"]

--- a/e2e/rust/Cargo.toml
+++ b/e2e/rust/Cargo.toml
@@ -13,7 +13,7 @@ candid = { workspace = true }
 ic-certified-map = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
-serde = "1"
+serde = { workspace = true }
 serde_bytes = "0.11"
 
 [build-dependencies]

--- a/evm_rpc_types/CHANGELOG.md
+++ b/evm_rpc_types/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/evm_rpc_types/CHANGELOG.md
+++ b/evm_rpc_types/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- v1.0 `Nat256`: transparent wrapper around a `Nat` to guarantee that it fits in 256 bits.
+- v1.0 Move `BlockTag` to this crate.
+- v1.0 Move `FeeHistoryArgs` and `FeeHistory` to this crate.

--- a/evm_rpc_types/Cargo.toml
+++ b/evm_rpc_types/Cargo.toml
@@ -9,3 +9,7 @@ edition = "2021"
 [dependencies]
 candid = { workspace = true }
 serde = { workspace = true }
+
+[dev-dependencies]
+num-bigint = { workspace = true }
+proptest = { workspace = true }

--- a/evm_rpc_types/Cargo.toml
+++ b/evm_rpc_types/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 
 [dependencies]
 candid = { workspace = true }
+num-bigint = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]
-num-bigint = { workspace = true }
 proptest = { workspace = true }

--- a/evm_rpc_types/Cargo.toml
+++ b/evm_rpc_types/Cargo.toml
@@ -7,3 +7,5 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
+candid = { workspace = true }
+serde = { workspace = true }

--- a/evm_rpc_types/Cargo.toml
+++ b/evm_rpc_types/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "evm_rpc_types"
+version = "0.1.0"
+description = "Candid types for interacting with the EVM RPC canister"
+authors = ["DFINITY Foundation"]
+readme = "README.md"
+edition = "2021"
+
+[dependencies]

--- a/evm_rpc_types/README.md
+++ b/evm_rpc_types/README.md
@@ -1,0 +1,3 @@
+# EVM RPC Types
+
+This crate defines types for interacting with the EVM RPC canister.

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod request;
+pub mod response;

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -5,8 +5,10 @@ use candid::types::{Serializer, Type};
 use candid::{CandidType, Nat};
 use serde::Deserialize;
 
-pub mod request;
-pub mod response;
+mod request;
+mod response;
+
+pub use request::FeeHistoryArgs;
 
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize, Default)]
 pub enum BlockTag {

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -3,12 +3,14 @@ mod tests;
 
 use candid::types::{Serializer, Type};
 use candid::{CandidType, Nat};
+use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
 mod request;
 mod response;
 
 pub use request::FeeHistoryArgs;
+pub use response::FeeHistory;
 
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize, Default)]
 pub enum BlockTag {
@@ -37,6 +39,11 @@ impl Nat256 {
         );
         value_u256[32 - value_bytes.len()..].copy_from_slice(&value_bytes);
         value_u256
+    }
+
+    pub fn from_be_bytes(value: [u8; 32]) -> Self {
+        Self::try_from(Nat::from(BigUint::from_bytes_be(&value)))
+            .expect("BUG: Nat should fit in a U256")
     }
 }
 

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -1,3 +1,4 @@
+use candid::types::{Serializer, Type};
 use candid::{CandidType, Nat};
 use serde::Deserialize;
 
@@ -12,5 +13,41 @@ pub enum BlockTag {
     Safe,
     Earliest,
     Pending,
-    Number(Nat),
+    Number(Nat256),
+}
+
+/// A `Nat` that is guaranteed to fit in 256 bits.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(try_from = "candid::Nat")]
+pub struct Nat256(Nat);
+
+impl AsRef<Nat> for Nat256 {
+    fn as_ref(&self) -> &Nat {
+        &self.0
+    }
+}
+
+impl CandidType for Nat256 {
+    fn _ty() -> Type {
+        Nat::_ty()
+    }
+
+    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_nat(self.as_ref())
+    }
+}
+
+impl TryFrom<Nat> for Nat256 {
+    type Error = String;
+
+    fn try_from(value: Nat) -> Result<Self, Self::Error> {
+        if value.0.to_bytes_le().len() > 32 {
+            Err("Nat does not fit in a U256".to_string())
+        } else {
+            Ok(Nat256(value))
+        }
+    }
 }

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -1,2 +1,16 @@
+use candid::{CandidType, Nat};
+use serde::Deserialize;
+
 pub mod request;
 pub mod response;
+
+#[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize, Default)]
+pub enum BlockTag {
+    #[default]
+    Latest,
+    Finalized,
+    Safe,
+    Earliest,
+    Pending,
+    Number(Nat),
+}

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -24,6 +24,20 @@ pub enum BlockTag {
 #[serde(try_from = "candid::Nat")]
 pub struct Nat256(Nat);
 
+impl Nat256 {
+    pub fn into_be_bytes(self) -> [u8; 32] {
+        let value_bytes = self.0 .0.to_bytes_be();
+        let mut value_u256 = [0u8; 32];
+        assert!(
+            value_bytes.len() <= 32,
+            "BUG: Nat does not fit in a U256: {:?}",
+            self.0
+        );
+        value_u256[32 - value_bytes.len()..].copy_from_slice(&value_bytes);
+        value_u256
+    }
+}
+
 impl AsRef<Nat> for Nat256 {
     fn as_ref(&self) -> &Nat {
         &self.0

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -25,7 +25,7 @@ pub enum BlockTag {
 
 /// A `Nat` that is guaranteed to fit in 256 bits.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(try_from = "candid::Nat")]
+#[serde(try_from = "candid::Nat", into = "candid::Nat")]
 pub struct Nat256(Nat);
 
 impl Nat256 {
@@ -75,6 +75,12 @@ impl TryFrom<Nat> for Nat256 {
         } else {
             Ok(Nat256(value))
         }
+    }
+}
+
+impl From<Nat256> for Nat {
+    fn from(value: Nat256) -> Self {
+        value.0
     }
 }
 

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -68,3 +68,14 @@ impl TryFrom<Nat> for Nat256 {
         }
     }
 }
+
+macro_rules! impl_from_unchecked {
+    ($f: ty, $($t: ty)*) => ($(
+        impl From<$t> for $f {
+            #[inline]
+            fn from(v: $t) -> Self { Self::try_from(Nat::from(v)).unwrap() }
+        }
+    )*)
+}
+// all the types below are guaranteed to fit in 256 bits
+impl_from_unchecked!( Nat256, usize u8 u16 u32 u64 u128 );

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -3,7 +3,7 @@ mod tests;
 
 use candid::types::{Serializer, Type};
 use candid::{CandidType, Nat};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 mod request;
 mod response;
@@ -22,7 +22,7 @@ pub enum BlockTag {
 }
 
 /// A `Nat` that is guaranteed to fit in 256 bits.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "candid::Nat")]
 pub struct Nat256(Nat);
 

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 use candid::types::{Serializer, Type};
 use candid::{CandidType, Nat};
 use serde::Deserialize;

--- a/evm_rpc_types/src/request/mod.rs
+++ b/evm_rpc_types/src/request/mod.rs
@@ -6,15 +6,18 @@ use serde::Deserialize;
 pub struct FeeHistoryArgs {
     /// Number of blocks in the requested range.
     /// Typically, providers request this to be between 1 and 1024.
+    #[serde(rename = "blockCount")]
     pub block_count: Nat256,
 
     /// Highest block of the requested range.
     /// Integer block number, or "latest" for the last mined block or "pending", "earliest" for not yet mined transactions.
+    #[serde(rename = "newestBlock")]
     pub newest_block: BlockTag,
 
     /// A monotonically increasing list of percentile values between 0 and 100.
     /// For each block in the requested range, the transactions will be sorted in ascending order
     /// by effective tip per gas and the corresponding effective tip for the percentile
     /// will be determined, accounting for gas consumed.
+    #[serde(rename = "rewardPercentiles")]
     pub reward_percentiles: Option<Vec<u8>>,
 }

--- a/evm_rpc_types/src/request/mod.rs
+++ b/evm_rpc_types/src/request/mod.rs
@@ -1,0 +1,20 @@
+use crate::BlockTag;
+use candid::CandidType;
+use serde::Deserialize;
+
+#[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize)]
+pub struct FeeHistoryArgs {
+    /// Number of blocks in the requested range.
+    /// Typically, providers request this to be between 1 and 1024.
+    pub block_count: u128,
+
+    /// Highest block of the requested range.
+    /// Integer block number, or "latest" for the last mined block or "pending", "earliest" for not yet mined transactions.
+    pub newest_block: BlockTag,
+
+    /// A monotonically increasing list of percentile values between 0 and 100.
+    /// For each block in the requested range, the transactions will be sorted in ascending order
+    /// by effective tip per gas and the corresponding effective tip for the percentile
+    /// will be determined, accounting for gas consumed.
+    pub reward_percentiles: Option<Vec<u8>>,
+}

--- a/evm_rpc_types/src/request/mod.rs
+++ b/evm_rpc_types/src/request/mod.rs
@@ -1,4 +1,4 @@
-use crate::BlockTag;
+use crate::{BlockTag, Nat256};
 use candid::CandidType;
 use serde::Deserialize;
 
@@ -6,7 +6,7 @@ use serde::Deserialize;
 pub struct FeeHistoryArgs {
     /// Number of blocks in the requested range.
     /// Typically, providers request this to be between 1 and 1024.
-    pub block_count: u128,
+    pub block_count: Nat256,
 
     /// Highest block of the requested range.
     /// Integer block number, or "latest" for the last mined block or "pending", "earliest" for not yet mined transactions.

--- a/evm_rpc_types/src/response/mod.rs
+++ b/evm_rpc_types/src/response/mod.rs
@@ -4,14 +4,18 @@ use candid::CandidType;
 #[derive(Debug, Clone, PartialEq, CandidType)]
 pub struct FeeHistory {
     /// Lowest number block of the returned range.
+    #[serde(rename = "oldestBlock")]
     pub oldest_block: Nat256,
     /// An array of block base fees per gas.
     /// This includes the next block after the newest of the returned range,
     /// because this value can be derived from the newest block.
     /// Zeroes are returned for pre-EIP-1559 blocks.
+    #[serde(rename = "baseFeePerGas")]
     pub base_fee_per_gas: Vec<Nat256>,
     /// An array of block gas used ratios (gasUsed / gasLimit).
+    #[serde(rename = "gasUsedRatio")]
     pub gas_used_ratio: Vec<f64>,
     /// A two-dimensional array of effective priority fees per gas at the requested block percentiles.
+    #[serde(rename = "reward")]
     pub reward: Vec<Vec<Nat256>>,
 }

--- a/evm_rpc_types/src/response/mod.rs
+++ b/evm_rpc_types/src/response/mod.rs
@@ -1,0 +1,16 @@
+use candid::{CandidType, Nat};
+
+#[derive(Debug, Clone, PartialEq, CandidType)]
+pub struct FeeHistory {
+    /// Lowest number block of the returned range.
+    pub oldest_block: Nat,
+    /// An array of block base fees per gas.
+    /// This includes the next block after the newest of the returned range,
+    /// because this value can be derived from the newest block.
+    /// Zeroes are returned for pre-EIP-1559 blocks.
+    pub base_fee_per_gas: Vec<Nat>,
+    /// An array of block gas used ratios (gasUsed / gasLimit).
+    pub gas_used_ratio: Vec<f64>,
+    /// A two-dimensional array of effective priority fees per gas at the requested block percentiles.
+    pub reward: Vec<Vec<Nat>>,
+}

--- a/evm_rpc_types/src/response/mod.rs
+++ b/evm_rpc_types/src/response/mod.rs
@@ -1,16 +1,17 @@
-use candid::{CandidType, Nat};
+use crate::Nat256;
+use candid::CandidType;
 
 #[derive(Debug, Clone, PartialEq, CandidType)]
 pub struct FeeHistory {
     /// Lowest number block of the returned range.
-    pub oldest_block: Nat,
+    pub oldest_block: Nat256,
     /// An array of block base fees per gas.
     /// This includes the next block after the newest of the returned range,
     /// because this value can be derived from the newest block.
     /// Zeroes are returned for pre-EIP-1559 blocks.
-    pub base_fee_per_gas: Vec<Nat>,
+    pub base_fee_per_gas: Vec<Nat256>,
     /// An array of block gas used ratios (gasUsed / gasLimit).
     pub gas_used_ratio: Vec<f64>,
     /// A two-dimensional array of effective priority fees per gas at the requested block percentiles.
-    pub reward: Vec<Vec<Nat>>,
+    pub reward: Vec<Vec<Nat256>>,
 }

--- a/evm_rpc_types/src/response/mod.rs
+++ b/evm_rpc_types/src/response/mod.rs
@@ -1,21 +1,24 @@
 use crate::Nat256;
 use candid::CandidType;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Serialize, CandidType)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, CandidType)]
 pub struct FeeHistory {
     /// Lowest number block of the returned range.
     #[serde(rename = "oldestBlock")]
     pub oldest_block: Nat256,
+
     /// An array of block base fees per gas.
     /// This includes the next block after the newest of the returned range,
     /// because this value can be derived from the newest block.
     /// Zeroes are returned for pre-EIP-1559 blocks.
     #[serde(rename = "baseFeePerGas")]
     pub base_fee_per_gas: Vec<Nat256>,
+
     /// An array of block gas used ratios (gasUsed / gasLimit).
     #[serde(rename = "gasUsedRatio")]
     pub gas_used_ratio: Vec<f64>,
+
     /// A two-dimensional array of effective priority fees per gas at the requested block percentiles.
     #[serde(rename = "reward")]
     pub reward: Vec<Vec<Nat256>>,

--- a/evm_rpc_types/src/response/mod.rs
+++ b/evm_rpc_types/src/response/mod.rs
@@ -4,18 +4,14 @@ use candid::CandidType;
 #[derive(Debug, Clone, PartialEq, CandidType)]
 pub struct FeeHistory {
     /// Lowest number block of the returned range.
-    #[serde(rename = "oldestBlock")]
     pub oldest_block: Nat256,
     /// An array of block base fees per gas.
     /// This includes the next block after the newest of the returned range,
     /// because this value can be derived from the newest block.
     /// Zeroes are returned for pre-EIP-1559 blocks.
-    #[serde(rename = "baseFeePerGas")]
     pub base_fee_per_gas: Vec<Nat256>,
     /// An array of block gas used ratios (gasUsed / gasLimit).
-    #[serde(rename = "gasUsedRatio")]
     pub gas_used_ratio: Vec<f64>,
     /// A two-dimensional array of effective priority fees per gas at the requested block percentiles.
-    #[serde(rename = "reward")]
     pub reward: Vec<Vec<Nat256>>,
 }

--- a/evm_rpc_types/src/response/mod.rs
+++ b/evm_rpc_types/src/response/mod.rs
@@ -1,7 +1,8 @@
 use crate::Nat256;
 use candid::CandidType;
+use serde::Serialize;
 
-#[derive(Debug, Clone, PartialEq, CandidType)]
+#[derive(Debug, Clone, PartialEq, Serialize, CandidType)]
 pub struct FeeHistory {
     /// Lowest number block of the returned range.
     #[serde(rename = "oldestBlock")]

--- a/evm_rpc_types/src/tests.rs
+++ b/evm_rpc_types/src/tests.rs
@@ -32,9 +32,9 @@ mod nat256 {
         #[test]
         fn should_convert_to_bytes_and_back(u256 in arb_u256()) {
             let value = Nat256::try_from(Nat::from(u256)).unwrap();
-
             let bytes = value.clone().into_be_bytes();
-            let value_from_bytes = Nat256::try_from(Nat::from(BigUint::from_bytes_be(&bytes))).unwrap();
+
+            let value_from_bytes = Nat256::from_be_bytes(bytes);
 
             assert_eq!(value, value_from_bytes);
         }

--- a/evm_rpc_types/src/tests.rs
+++ b/evm_rpc_types/src/tests.rs
@@ -28,6 +28,16 @@ mod nat256 {
                 error_msg
             );
         }
+
+        #[test]
+        fn should_convert_to_bytes_and_back(u256 in arb_u256()) {
+            let value = Nat256::try_from(Nat::from(u256)).unwrap();
+
+            let bytes = value.clone().into_be_bytes();
+            let value_from_bytes = Nat256::try_from(Nat::from(BigUint::from_bytes_be(&bytes))).unwrap();
+
+            assert_eq!(value, value_from_bytes);
+        }
     }
 
     fn encode_decode_roundtrip(value: BigUint) {

--- a/evm_rpc_types/src/tests.rs
+++ b/evm_rpc_types/src/tests.rs
@@ -1,0 +1,50 @@
+mod nat256 {
+    use crate::Nat256;
+    use candid::{Decode, Encode, Nat};
+    use num_bigint::BigUint;
+    use proptest::{arbitrary::any, prelude::Strategy, proptest};
+
+    proptest! {
+        #[test]
+        fn should_encode_decode(u256 in arb_u256()) {
+            encode_decode_roundtrip(u256);
+        }
+
+        #[test]
+        fn should_fail_to_decode_nat_overflowing_a_u256(offset in any::<u64>()) {
+            let u256_max: BigUint = BigUint::from_bytes_be(&[0xff; 32]);
+            encode_decode_roundtrip(u256_max.clone());
+
+            let offset = BigUint::from(offset);
+            let overflow_u256 = Nat::from(u256_max + offset);
+            let encoded_overflow_u256 = Encode!(&overflow_u256).unwrap();
+
+            let decoded_overflow_nat256: Result<Nat256, _> = Decode!(&encoded_overflow_u256, Nat256);
+            let error_msg = format!("{:?}", decoded_overflow_nat256.unwrap_err());
+
+            assert!(
+                error_msg.contains("Deserialize error: Nat does not fit in a U256"),
+                "Unexpected error message: {}",
+                error_msg
+            );
+        }
+    }
+
+    fn encode_decode_roundtrip(value: BigUint) {
+        let nat = Nat::from(value);
+        let encoded_nat = Encode!(&nat).unwrap();
+
+        let nat256 = Nat256::try_from(nat.clone()).unwrap();
+        let encoded_nat256 = Encode!(&nat256).unwrap();
+
+        assert_eq!(encoded_nat, encoded_nat256);
+
+        let decoded_nat256: Nat256 = Decode!(&encoded_nat, Nat256).unwrap();
+        assert_eq!(decoded_nat256.0, nat);
+    }
+
+    fn arb_u256() -> impl Strategy<Value = BigUint> {
+        use proptest::array::uniform32;
+        uniform32(any::<u8>()).prop_map(|value| BigUint::from_bytes_be(&value))
+    }
+}

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -1,3 +1,5 @@
+mod cketh_conversion;
+
 use std::str::FromStr;
 
 use async_trait::async_trait;
@@ -248,11 +250,17 @@ impl CandidRpcClient {
 
     pub async fn eth_fee_history(
         &self,
-        args: candid_types::FeeHistoryArgs,
+        args: evm_rpc_types::FeeHistoryArgs,
     ) -> MultiRpcResult<FeeHistory> {
+        use crate::candid_rpc::cketh_conversion::{into_block_spec, into_quantity};
+        let args = cketh_common::eth_rpc::FeeHistoryParams {
+            block_count: into_quantity(args.block_count),
+            highest_block: into_block_spec(args.newest_block),
+            reward_percentiles: args.reward_percentiles.unwrap_or_default(),
+        };
         process_result(
             RpcMethod::EthFeeHistory,
-            self.client.eth_fee_history(args.into()).await,
+            self.client.eth_fee_history(args).await,
         )
         .map(|history| history)
     }

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use cketh_common::{
     eth_rpc::{
-        into_nat, Block, FeeHistory, GetLogsParam, Hash, LogEntry, ProviderError, RpcError,
+        into_nat, Block, GetLogsParam, Hash, LogEntry, ProviderError, RpcError,
         SendRawTransactionResult, ValidationError,
     },
     eth_rpc_client::{
@@ -251,8 +251,10 @@ impl CandidRpcClient {
     pub async fn eth_fee_history(
         &self,
         args: evm_rpc_types::FeeHistoryArgs,
-    ) -> MultiRpcResult<FeeHistory> {
-        use crate::candid_rpc::cketh_conversion::{into_block_spec, into_quantity};
+    ) -> MultiRpcResult<evm_rpc_types::FeeHistory> {
+        use crate::candid_rpc::cketh_conversion::{
+            from_fee_history, into_block_spec, into_quantity,
+        };
         let args = cketh_common::eth_rpc::FeeHistoryParams {
             block_count: into_quantity(args.block_count),
             highest_block: into_block_spec(args.newest_block),
@@ -262,7 +264,7 @@ impl CandidRpcClient {
             RpcMethod::EthFeeHistory,
             self.client.eth_fee_history(args).await,
         )
-        .map(|history| history)
+        .map(from_fee_history)
     }
 
     pub async fn eth_send_raw_transaction(

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -252,17 +252,12 @@ impl CandidRpcClient {
         &self,
         args: evm_rpc_types::FeeHistoryArgs,
     ) -> MultiRpcResult<evm_rpc_types::FeeHistory> {
-        use crate::candid_rpc::cketh_conversion::{
-            from_fee_history, into_block_spec, into_quantity,
-        };
-        let args = cketh_common::eth_rpc::FeeHistoryParams {
-            block_count: into_quantity(args.block_count),
-            highest_block: into_block_spec(args.newest_block),
-            reward_percentiles: args.reward_percentiles.unwrap_or_default(),
-        };
+        use crate::candid_rpc::cketh_conversion::{from_fee_history, into_fee_history_params};
         process_result(
             RpcMethod::EthFeeHistory,
-            self.client.eth_fee_history(args).await,
+            self.client
+                .eth_fee_history(into_fee_history_params(args))
+                .await,
         )
         .map(from_fee_history)
     }

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -6,18 +6,6 @@ use cketh_common::checked_amount::CheckedAmountOf;
 use cketh_common::eth_rpc::Quantity;
 use evm_rpc_types::{BlockTag, Nat256};
 
-fn into_checked_amount_of<Unit>(value: Nat256) -> CheckedAmountOf<Unit> {
-    CheckedAmountOf::from_be_bytes(value.into_be_bytes())
-}
-
-fn from_checked_amount_of<Unit>(value: CheckedAmountOf<Unit>) -> Nat256 {
-    Nat256::from_be_bytes(value.to_be_bytes())
-}
-
-pub(super) fn into_quantity(value: Nat256) -> Quantity {
-    Quantity::from_be_bytes(value.into_be_bytes())
-}
-
 pub(super) fn into_block_spec(value: BlockTag) -> cketh_common::eth_rpc::BlockSpec {
     use cketh_common::eth_rpc::{self, BlockSpec};
     match value {
@@ -27,6 +15,16 @@ pub(super) fn into_block_spec(value: BlockTag) -> cketh_common::eth_rpc::BlockSp
         BlockTag::Finalized => BlockSpec::Tag(eth_rpc::BlockTag::Finalized),
         BlockTag::Earliest => BlockSpec::Tag(eth_rpc::BlockTag::Earliest),
         BlockTag::Pending => BlockSpec::Tag(eth_rpc::BlockTag::Pending),
+    }
+}
+
+pub(super) fn into_fee_history_params(
+    value: evm_rpc_types::FeeHistoryArgs,
+) -> cketh_common::eth_rpc::FeeHistoryParams {
+    cketh_common::eth_rpc::FeeHistoryParams {
+        block_count: into_quantity(value.block_count),
+        highest_block: into_block_spec(value.newest_block),
+        reward_percentiles: value.reward_percentiles.unwrap_or_default(),
     }
 }
 
@@ -47,4 +45,16 @@ pub(super) fn from_fee_history(
             .map(|x| x.into_iter().map(from_checked_amount_of).collect())
             .collect(),
     }
+}
+
+fn into_checked_amount_of<Unit>(value: Nat256) -> CheckedAmountOf<Unit> {
+    CheckedAmountOf::from_be_bytes(value.into_be_bytes())
+}
+
+fn from_checked_amount_of<Unit>(value: CheckedAmountOf<Unit>) -> Nat256 {
+    Nat256::from_be_bytes(value.to_be_bytes())
+}
+
+fn into_quantity(value: Nat256) -> Quantity {
+    Quantity::from_be_bytes(value.into_be_bytes())
 }

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -1,0 +1,26 @@
+//! Conversion between ckETH types and EVM RPC types.
+//! This module is meant to be temporary and should be removed once the dependency on ckETH is removed.
+
+use cketh_common::checked_amount::CheckedAmountOf;
+use cketh_common::eth_rpc::Quantity;
+use evm_rpc_types::{BlockTag, Nat256};
+
+fn into_checked_amount_of<Unit>(value: Nat256) -> CheckedAmountOf<Unit> {
+    CheckedAmountOf::from_be_bytes(value.into_be_bytes())
+}
+
+pub(super) fn into_quantity(value: Nat256) -> Quantity {
+    Quantity::from_be_bytes(value.into_be_bytes())
+}
+
+pub(super) fn into_block_spec(value: BlockTag) -> cketh_common::eth_rpc::BlockSpec {
+    use cketh_common::eth_rpc::{self, BlockSpec};
+    match value {
+        BlockTag::Number(n) => BlockSpec::Number(into_checked_amount_of(n)),
+        BlockTag::Latest => BlockSpec::Tag(eth_rpc::BlockTag::Latest),
+        BlockTag::Safe => BlockSpec::Tag(eth_rpc::BlockTag::Safe),
+        BlockTag::Finalized => BlockSpec::Tag(eth_rpc::BlockTag::Finalized),
+        BlockTag::Earliest => BlockSpec::Tag(eth_rpc::BlockTag::Earliest),
+        BlockTag::Pending => BlockSpec::Tag(eth_rpc::BlockTag::Pending),
+    }
+}

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -1,5 +1,6 @@
 //! Conversion between ckETH types and EVM RPC types.
-//! This module is meant to be temporary and should be removed once the dependency on ckETH is removed.
+//! This module is meant to be temporary and should be removed once the dependency on ckETH is removed,
+//! see https://github.com/internet-computer-protocol/evm-rpc-canister/issues/243
 
 use cketh_common::checked_amount::CheckedAmountOf;
 use cketh_common::eth_rpc::Quantity;

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -10,6 +10,10 @@ fn into_checked_amount_of<Unit>(value: Nat256) -> CheckedAmountOf<Unit> {
     CheckedAmountOf::from_be_bytes(value.into_be_bytes())
 }
 
+fn from_checked_amount_of<Unit>(value: CheckedAmountOf<Unit>) -> Nat256 {
+    Nat256::from_be_bytes(value.to_be_bytes())
+}
+
 pub(super) fn into_quantity(value: Nat256) -> Quantity {
     Quantity::from_be_bytes(value.into_be_bytes())
 }
@@ -23,5 +27,24 @@ pub(super) fn into_block_spec(value: BlockTag) -> cketh_common::eth_rpc::BlockSp
         BlockTag::Finalized => BlockSpec::Tag(eth_rpc::BlockTag::Finalized),
         BlockTag::Earliest => BlockSpec::Tag(eth_rpc::BlockTag::Earliest),
         BlockTag::Pending => BlockSpec::Tag(eth_rpc::BlockTag::Pending),
+    }
+}
+
+pub(super) fn from_fee_history(
+    value: cketh_common::eth_rpc::FeeHistory,
+) -> evm_rpc_types::FeeHistory {
+    evm_rpc_types::FeeHistory {
+        oldest_block: from_checked_amount_of(value.oldest_block),
+        base_fee_per_gas: value
+            .base_fee_per_gas
+            .into_iter()
+            .map(from_checked_amount_of)
+            .collect(),
+        gas_used_ratio: value.gas_used_ratio,
+        reward: value
+            .reward
+            .into_iter()
+            .map(|x| x.into_iter().map(from_checked_amount_of).collect())
+            .collect(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ pub async fn eth_fee_history(
     source: RpcServices,
     config: Option<RpcConfig>,
     args: evm_rpc_types::FeeHistoryArgs,
-) -> MultiRpcResult<FeeHistory> {
+) -> MultiRpcResult<evm_rpc_types::FeeHistory> {
     match CandidRpcClient::new(source, config) {
         Ok(source) => source.eth_fee_history(args).await,
         Err(err) => Err(err).into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,7 @@ pub async fn eth_get_transaction_count(
 pub async fn eth_fee_history(
     source: RpcServices,
     config: Option<RpcConfig>,
-    args: candid_types::FeeHistoryArgs,
+    args: evm_rpc_types::FeeHistoryArgs,
 ) -> MultiRpcResult<FeeHistory> {
     match CandidRpcClient::new(source, config) {
         Ok(source) => source.eth_fee_history(args).await,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use candid::{candid_method, Principal};
-use cketh_common::eth_rpc::{Block, FeeHistory, LogEntry, RpcError};
+use cketh_common::eth_rpc::{Block, LogEntry, RpcError};
 
 use cketh_common::eth_rpc_client::providers::RpcService;
 use cketh_common::eth_rpc_client::RpcConfig;

--- a/src/types.rs
+++ b/src/types.rs
@@ -637,26 +637,6 @@ pub mod candid_types {
     }
 
     #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize)]
-    pub struct FeeHistoryArgs {
-        #[serde(rename = "blockCount")]
-        pub block_count: u128,
-        #[serde(rename = "newestBlock")]
-        pub newest_block: BlockTag,
-        #[serde(rename = "rewardPercentiles")]
-        pub reward_percentiles: Option<Vec<u8>>,
-    }
-
-    impl From<FeeHistoryArgs> for cketh_common::eth_rpc::FeeHistoryParams {
-        fn from(value: FeeHistoryArgs) -> Self {
-            cketh_common::eth_rpc::FeeHistoryParams {
-                block_count: value.block_count.into(),
-                highest_block: value.newest_block.into(),
-                reward_percentiles: value.reward_percentiles.unwrap_or_default(),
-            }
-        }
-    }
-
-    #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize)]
     pub struct GetTransactionCountArgs {
         pub address: String,
         pub block: BlockTag,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -8,8 +8,8 @@ use cketh_common::{
     address::Address,
     checked_amount::CheckedAmountOf,
     eth_rpc::{
-        Block, Data, FeeHistory, FixedSizeData, Hash, HttpOutcallError, JsonRpcError, LogEntry,
-        ProviderError, RpcError,
+        Block, Data, FixedSizeData, Hash, HttpOutcallError, JsonRpcError, LogEntry, ProviderError,
+        RpcError,
     },
     eth_rpc_client::{
         providers::{EthMainnetService, EthSepoliaService, RpcApi, RpcService},
@@ -44,6 +44,7 @@ use evm_rpc::{
         RegisterProviderArgs, RpcMethod, RpcResult, RpcServices, UpdateProviderArgs,
     },
 };
+use evm_rpc_types::Nat256;
 use mock::{MockOutcall, MockOutcallBuilder};
 
 const DEFAULT_CALLER_TEST_ID: u64 = 10352385;
@@ -318,7 +319,7 @@ impl EvmRpcSetup {
         source: RpcServices,
         config: Option<RpcConfig>,
         args: evm_rpc_types::FeeHistoryArgs,
-    ) -> CallFlow<MultiRpcResult<Option<FeeHistory>>> {
+    ) -> CallFlow<MultiRpcResult<Option<evm_rpc_types::FeeHistory>>> {
         self.call_update("eth_feeHistory", Encode!(&source, &config, &args).unwrap())
     }
 
@@ -1275,14 +1276,14 @@ fn eth_fee_history_should_succeed() {
         .unwrap();
         assert_eq!(
             response,
-            Some(FeeHistory {
-                oldest_block: CheckedAmountOf::new(0x11e57f5),
-                base_fee_per_gas: vec!["0x9cf6c61b9", "0x97d853982", "0x9ba55a0b0", "0x9543bf98d"]
+            Some(evm_rpc_types::FeeHistory {
+                oldest_block: Nat256::from(0x11e57f5_u64),
+                base_fee_per_gas: vec![0x9cf6c61b9_u64, 0x97d853982, 0x9ba55a0b0, 0x9543bf98d]
                     .into_iter()
-                    .map(|hex| CheckedAmountOf::from_str_hex(hex).unwrap())
+                    .map(Nat256::from)
                     .collect(),
                 gas_used_ratio: vec![],
-                reward: vec![vec![CheckedAmountOf::new(0x0123)]],
+                reward: vec![vec![Nat256::from(0x0123_u32)]],
             })
         );
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1261,7 +1261,7 @@ fn eth_fee_history_should_succeed() {
             source.clone(),
             None,
             evm_rpc_types::FeeHistoryArgs {
-                block_count: 3.into(),
+                block_count: 3_u8.into(),
                 newest_block: evm_rpc_types::BlockTag::Latest,
                 reward_percentiles: None,
             },

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -317,7 +317,7 @@ impl EvmRpcSetup {
         &self,
         source: RpcServices,
         config: Option<RpcConfig>,
-        args: candid_types::FeeHistoryArgs,
+        args: evm_rpc_types::FeeHistoryArgs,
     ) -> CallFlow<MultiRpcResult<Option<FeeHistory>>> {
         self.call_update("eth_feeHistory", Encode!(&source, &config, &args).unwrap())
     }
@@ -1260,9 +1260,9 @@ fn eth_fee_history_should_succeed() {
         .eth_fee_history(
             source.clone(),
             None,
-            candid_types::FeeHistoryArgs {
-                block_count: 3,
-                newest_block: candid_types::BlockTag::Latest,
+            evm_rpc_types::FeeHistoryArgs {
+                block_count: 3.into(),
+                newest_block: evm_rpc_types::BlockTag::Latest,
                 reward_percentiles: None,
             },
         )


### PR DESCRIPTION
Introduce a new crate `evm_rpc_types` that will contain all Candid types necessary to interact with the EVM RPC canister. As a first step for #243 :

1. Introduce `Nat256` as a wrapper around a `Nat` that is guaranteed to have the same encoding/decoding as a `Nat`, while ensuring that it fits in a `U256` bits.
2. As an example, refactor `eth_fee_history` so that the public API only uses types from the new `evm_rpc_types` crate .