### PR TITLE
Minor typo in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Run the following commands to set up a local development environment:
 ```bash
 # Clone the repository and install dependencies
 git clone https://github.com/internet-computer-protocol/evm-rpc-canister
-cd ic-eth-rpc
+cd evm-rpc-canister
 npm install
 
 # Deploy to the local replica


### PR DESCRIPTION
- Incorrect Command: cd ic-eth-rpc
- Corrected Command: cd evm-rpc-canister This change ensures that the instructions align correctly with the cloned repository directory name.