### PR TITLE
refactor: move `GetLogsArgs` and `LogEntry` to the `evm_rpc_types` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,6 +1618,7 @@ name = "evm_rpc_types"
 version = "0.1.0"
 dependencies = [
  "candid",
+ "hex",
  "num-bigint 0.4.6",
  "proptest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ assert_matches = "1.5"
 [workspace.dependencies]
 candid = { version = "0.9" }
 getrandom = { version = "0.2", features = ["custom"] }
+hex = "0.4.3"
 ic-canisters-http-types = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
 ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
 ic-metrics-encoder = "1.1"

--- a/evm_rpc_types/CHANGELOG.md
+++ b/evm_rpc_types/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - v1.0 `Nat256`: transparent wrapper around a `Nat` to guarantee that it fits in 256 bits.
-- v1.0 `Hex`, `Hex20`, and `Hex32`: transparent wrapper around a Candid type `text` to represent Ethereum hex strings (prefixed by `0x`) containing an unbounded, 20 or 32 bytes, respectively.
+- v1.0 `Hex`, `Hex20`, and `Hex32`: Candid types wrapping an amount of bytes (`Vec<u8>` for `Hex` and `[u8; N]` for `HexN`) that can be represented as an hexadecimal string (prefixed by `0x`) when serialized.
 - v1.0 Move `BlockTag` to this crate.
 - v1.0 Move `FeeHistoryArgs` and `FeeHistory` to this crate.
 - v1.0 Move `GetLogsArgs` and `LogEntry` to this crate.

--- a/evm_rpc_types/CHANGELOG.md
+++ b/evm_rpc_types/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - v1.0 `Nat256`: transparent wrapper around a `Nat` to guarantee that it fits in 256 bits.
+- v1.0 `Hex`, `Hex20`, and `Hex32`: transparent wrapper around a Candid type `text` to represent Ethereum hex strings (prefixed by `0x`) containing an unbounded, 20 or 32 bytes, respectively.
 - v1.0 Move `BlockTag` to this crate.
 - v1.0 Move `FeeHistoryArgs` and `FeeHistory` to this crate.
 - v1.0 Move `GetLogsArgs` and `LogEntry` to this crate.

--- a/evm_rpc_types/CHANGELOG.md
+++ b/evm_rpc_types/CHANGELOG.md
@@ -12,4 +12,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - v1.0 `Nat256`: transparent wrapper around a `Nat` to guarantee that it fits in 256 bits.
 - v1.0 Move `BlockTag` to this crate.
 - v1.0 Move `FeeHistoryArgs` and `FeeHistory` to this crate.
-- v1.0 Move `GetLogsArgs` to this crate.
+- v1.0 Move `GetLogsArgs` and `LogEntry` to this crate.

--- a/evm_rpc_types/CHANGELOG.md
+++ b/evm_rpc_types/CHANGELOG.md
@@ -12,3 +12,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - v1.0 `Nat256`: transparent wrapper around a `Nat` to guarantee that it fits in 256 bits.
 - v1.0 Move `BlockTag` to this crate.
 - v1.0 Move `FeeHistoryArgs` and `FeeHistory` to this crate.
+- v1.0 Move `GetLogsArgs` to this crate.

--- a/evm_rpc_types/Cargo.toml
+++ b/evm_rpc_types/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 candid = { workspace = true }
+hex = { workspace = true }
 num-bigint = { workspace = true }
 serde = { workspace = true }
 

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -165,7 +165,6 @@ macro_rules! impl_hex_string {
     };
 }
 
-// TODO 243: add unit tests
 impl_hex_string!(Hex20([u8; 20]));
 impl_hex_string!(Hex32([u8; 32]));
 impl_hex_string!(Hex(Vec<u8>));

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -5,11 +5,13 @@ use candid::types::{Serializer, Type};
 use candid::{CandidType, Nat};
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 
 mod request;
 mod response;
 
-pub use request::FeeHistoryArgs;
+pub use request::{FeeHistoryArgs, GetLogsArgs};
 pub use response::FeeHistory;
 
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize, Default)]
@@ -94,3 +96,73 @@ macro_rules! impl_from_unchecked {
 }
 // all the types below are guaranteed to fit in 256 bits
 impl_from_unchecked!( Nat256, usize u8 u16 u32 u64 u128 );
+
+// TODO 243: add unit tests
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct EthereumHexString<const N: usize>([u8; N]);
+
+impl<const N: usize> Display for EthereumHexString<N> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("0x")?;
+        f.write_str(&hex::encode(&self.0))
+    }
+}
+
+impl<const N: usize> CandidType for EthereumHexString<N> {
+    fn _ty() -> Type {
+        String::_ty()
+    }
+
+    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_text(&self.to_string())
+    }
+}
+
+impl<const N: usize> FromStr for EthereumHexString<N> {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if !s.starts_with("0x") {
+            return Err("Ethereum hex string doesn't start with 0x".to_string());
+        }
+        let s = &s[2..];
+        let expected_num_hex_chars = N * 2;
+        if s.len() != expected_num_hex_chars {
+            return Err(format!(
+                "Invalid hash: expected {} characters, got {}",
+                expected_num_hex_chars,
+                s.len()
+            ));
+        }
+        let mut bytes = [0u8; N];
+        hex::decode_to_slice(s, &mut bytes).map_err(|e| format!("Invalid hex string: {}", e))?;
+        Ok(Self(bytes))
+    }
+}
+
+impl<const N: usize> TryFrom<String> for EthereumHexString<N> {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+impl<const N: usize> From<EthereumHexString<N>> for String {
+    fn from(value: EthereumHexString<N>) -> Self {
+        value.to_string()
+    }
+}
+
+impl<const N: usize> From<EthereumHexString<N>> for [u8; N] {
+    fn from(value: EthereumHexString<N>) -> Self {
+        value.0
+    }
+}
+
+pub type Address = EthereumHexString<20>;
+pub type FixedSizeData = EthereumHexString<32>;

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -5,7 +5,7 @@ use candid::types::{Serializer, Type};
 use candid::{CandidType, Nat};
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
-use std::fmt::{Display, Formatter};
+use std::fmt::Formatter;
 use std::str::FromStr;
 
 mod request;
@@ -97,72 +97,75 @@ macro_rules! impl_from_unchecked {
 // all the types below are guaranteed to fit in 256 bits
 impl_from_unchecked!( Nat256, usize u8 u16 u32 u64 u128 );
 
+macro_rules! impl_hex_string {
+    ($name: ident($data: ty)) => {
+        #[doc = concat!("Ethereum hex-string (String representation is prefixed by 0x) wrapping a `", stringify!($data), "`. ")]
+        #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+        #[serde(try_from = "String", into = "String")]
+        pub struct $name($data);
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                f.write_str("0x")?;
+                f.write_str(&hex::encode(&self.0))
+            }
+        }
+
+        impl From<$data> for $name {
+            fn from(value: $data) -> Self {
+                Self(value)
+            }
+        }
+
+        impl From<$name> for $data {
+            fn from(value: $name) -> Self {
+                value.0
+            }
+        }
+
+        impl CandidType for $name {
+            fn _ty() -> Type {
+                String::_ty()
+            }
+
+            fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.serialize_text(&self.to_string())
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = String;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                if !s.starts_with("0x") {
+                    return Err("Ethereum hex string doesn't start with 0x".to_string());
+                }
+                hex::FromHex::from_hex(&s[2..])
+                    .map(Self)
+                    .map_err(|e| e.to_string())
+            }
+        }
+
+        impl TryFrom<String> for $name {
+            type Error = String;
+
+            fn try_from(value: String) -> Result<Self, Self::Error> {
+                value.parse()
+            }
+        }
+
+        impl From<$name> for String {
+            fn from(value: $name) -> Self {
+                value.to_string()
+            }
+        }
+    };
+}
+
 // TODO 243: add unit tests
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(try_from = "String", into = "String")]
-pub struct EthereumHexString<const N: usize>([u8; N]);
-
-impl<const N: usize> Display for EthereumHexString<N> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str("0x")?;
-        f.write_str(&hex::encode(&self.0))
-    }
-}
-
-impl<const N: usize> CandidType for EthereumHexString<N> {
-    fn _ty() -> Type {
-        String::_ty()
-    }
-
-    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_text(&self.to_string())
-    }
-}
-
-impl<const N: usize> FromStr for EthereumHexString<N> {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if !s.starts_with("0x") {
-            return Err("Ethereum hex string doesn't start with 0x".to_string());
-        }
-        let s = &s[2..];
-        let expected_num_hex_chars = N * 2;
-        if s.len() != expected_num_hex_chars {
-            return Err(format!(
-                "Invalid hash: expected {} characters, got {}",
-                expected_num_hex_chars,
-                s.len()
-            ));
-        }
-        let mut bytes = [0u8; N];
-        hex::decode_to_slice(s, &mut bytes).map_err(|e| format!("Invalid hex string: {}", e))?;
-        Ok(Self(bytes))
-    }
-}
-
-impl<const N: usize> TryFrom<String> for EthereumHexString<N> {
-    type Error = String;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        value.parse()
-    }
-}
-
-impl<const N: usize> From<EthereumHexString<N>> for String {
-    fn from(value: EthereumHexString<N>) -> Self {
-        value.to_string()
-    }
-}
-
-impl<const N: usize> From<EthereumHexString<N>> for [u8; N] {
-    fn from(value: EthereumHexString<N>) -> Self {
-        value.0
-    }
-}
-
-pub type Address = EthereumHexString<20>;
-pub type FixedSizeData = EthereumHexString<32>;
+impl_hex_string!(Hex20([u8; 20]));
+impl_hex_string!(Hex32([u8; 32]));
+impl_hex_string!(Hex(Vec<u8>));

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -145,7 +145,7 @@ macro_rules! impl_hex_string {
                 }
                 hex::FromHex::from_hex(&s[2..])
                     .map(Self)
-                    .map_err(|e| e.to_string())
+                    .map_err(|e| format!("Invalid Ethereum hex string: {}", e))
             }
         }
 

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -12,7 +12,7 @@ mod request;
 mod response;
 
 pub use request::{FeeHistoryArgs, GetLogsArgs};
-pub use response::FeeHistory;
+pub use response::{FeeHistory, LogEntry};
 
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize, Default)]
 pub enum BlockTag {

--- a/evm_rpc_types/src/request/mod.rs
+++ b/evm_rpc_types/src/request/mod.rs
@@ -1,4 +1,4 @@
-use crate::{Address, BlockTag, FixedSizeData, Nat256};
+use crate::{BlockTag, Hex20, Hex32, Nat256};
 use candid::CandidType;
 use serde::Deserialize;
 
@@ -33,10 +33,10 @@ pub struct GetLogsArgs {
     pub to_block: Option<BlockTag>,
 
     /// Contract address or a list of addresses from which logs should originate.
-    pub addresses: Vec<Address>,
+    pub addresses: Vec<Hex20>,
 
     /// Array of 32 Bytes DATA topics.
     /// Topics are order-dependent.
     /// Each topic can also be an array of DATA with "or" options.
-    pub topics: Option<Vec<Vec<FixedSizeData>>>,
+    pub topics: Option<Vec<Vec<Hex32>>>,
 }

--- a/evm_rpc_types/src/request/mod.rs
+++ b/evm_rpc_types/src/request/mod.rs
@@ -1,4 +1,4 @@
-use crate::{BlockTag, Nat256};
+use crate::{Address, BlockTag, FixedSizeData, Nat256};
 use candid::CandidType;
 use serde::Deserialize;
 
@@ -20,4 +20,23 @@ pub struct FeeHistoryArgs {
     /// will be determined, accounting for gas consumed.
     #[serde(rename = "rewardPercentiles")]
     pub reward_percentiles: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize)]
+pub struct GetLogsArgs {
+    /// Integer block number, or "latest" for the last mined block or "pending", "earliest" for not yet mined transactions.
+    #[serde(rename = "fromBlock")]
+    pub from_block: Option<BlockTag>,
+
+    /// Integer block number, or "latest" for the last mined block or "pending", "earliest" for not yet mined transactions.
+    #[serde(rename = "toBlock")]
+    pub to_block: Option<BlockTag>,
+
+    /// Contract address or a list of addresses from which logs should originate.
+    pub addresses: Vec<Address>,
+
+    /// Array of 32 Bytes DATA topics.
+    /// Topics are order-dependent.
+    /// Each topic can also be an array of DATA with "or" options.
+    pub topics: Option<Vec<Vec<FixedSizeData>>>,
 }

--- a/evm_rpc_types/src/request/mod.rs
+++ b/evm_rpc_types/src/request/mod.rs
@@ -35,7 +35,7 @@ pub struct GetLogsArgs {
     /// Contract address or a list of addresses from which logs should originate.
     pub addresses: Vec<Hex20>,
 
-    /// Array of 32 Bytes DATA topics.
+    /// Array of 32-byte DATA topics.
     /// Topics are order-dependent.
     /// Each topic can also be an array of DATA with "or" options.
     pub topics: Option<Vec<Vec<Hex32>>>,

--- a/evm_rpc_types/src/response/mod.rs
+++ b/evm_rpc_types/src/response/mod.rs
@@ -1,4 +1,4 @@
-use crate::Nat256;
+use crate::{Hex, Hex20, Hex32, Nat256};
 use candid::CandidType;
 use serde::{Deserialize, Serialize};
 
@@ -22,4 +22,48 @@ pub struct FeeHistory {
     /// A two-dimensional array of effective priority fees per gas at the requested block percentiles.
     #[serde(rename = "reward")]
     pub reward: Vec<Vec<Nat256>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, CandidType)]
+pub struct LogEntry {
+    /// The address from which this log originated.
+    pub address: Hex20,
+
+    /// Array of 0 to 4 32-byte DATA elements of indexed log arguments.
+    /// In solidity: The first topic is the event signature hash (e.g. Deposit(address,bytes32,uint256)),
+    /// unless you declared the event with the anonymous specifier.
+    pub topics: Vec<Hex32>,
+
+    /// Contains one or more 32-byte non-indexed log arguments.
+    pub data: Hex,
+
+    /// The block number in which this log appeared.
+    /// None if the block is pending.
+    #[serde(rename = "blockNumber")]
+    pub block_number: Option<Nat256>,
+
+    /// 32-byte hash of the transaction from which this log was created.
+    /// None if the transaction is still pending.
+    #[serde(rename = "transactionHash")]
+    pub transaction_hash: Option<Hex32>,
+
+    /// Integer of the transaction's position within the block the log was created from.
+    /// None if the transaction is still pending.
+    #[serde(rename = "transactionIndex")]
+    pub transaction_index: Option<Nat256>,
+
+    /// 32-byte hash of the block in which this log appeared.
+    /// None if the block is pending.
+    #[serde(rename = "blockHash")]
+    pub block_hash: Option<Hex32>,
+
+    /// Integer of the log index position in the block.
+    /// None if the log is pending.
+    #[serde(rename = "logIndex")]
+    pub log_index: Option<Nat256>,
+
+    /// "true" when the log was removed due to a chain reorganization.
+    /// "false" if it is a valid log.
+    #[serde(default)]
+    pub removed: bool,
 }

--- a/evm_rpc_types/src/tests.rs
+++ b/evm_rpc_types/src/tests.rs
@@ -58,3 +58,83 @@ mod nat256 {
         uniform32(any::<u8>()).prop_map(|value| BigUint::from_bytes_be(&value))
     }
 }
+
+mod hex_string {
+    use crate::{Hex, Hex20, Hex32};
+    use candid::{CandidType, Decode, Encode};
+    use proptest::prelude::{Strategy, TestCaseError};
+    use proptest::{prop_assert, prop_assert_eq, proptest};
+    use serde::de::DeserializeOwned;
+    use std::ops::RangeInclusive;
+    use std::str::FromStr;
+
+    proptest! {
+        #[test]
+        fn should_encode_decode(
+            hex20 in arb_var_len_hex_string(20..=20_usize),
+            hex32 in arb_var_len_hex_string(32..=32_usize),
+            hex in arb_var_len_hex_string(0..=100_usize)
+        ) {
+            encode_decode_roundtrip::<Hex20>(&hex20)?;
+            encode_decode_roundtrip::<Hex32>(&hex32)?;
+            encode_decode_roundtrip::<Hex>(&hex)?;
+        }
+
+        #[test]
+        fn should_fail_to_decode_strings_with_wrong_length(
+            short_hex20 in arb_var_len_hex_string(0..=19_usize),
+            long_hex20 in arb_var_len_hex_string(21..=100_usize),
+            short_hex32 in arb_var_len_hex_string(0..=31_usize),
+            long_hex32 in arb_var_len_hex_string(33..=100_usize),
+        ) {
+            let decoded_short_hex20 = Decode!(&Encode!(&short_hex20).unwrap(), Hex20);
+            let decoded_long_hex20 = Decode!(&Encode!(&long_hex20).unwrap(), Hex20);
+            for result in [decoded_short_hex20, decoded_long_hex20] {
+                prop_assert!(
+                    result.is_err(),
+                    "Expected error decoding hex20 with wrong length, got: {:?}",
+                    result
+                );
+            }
+
+            let decoded_short_hex32 = Decode!(&Encode!(&short_hex32).unwrap(), Hex32);
+            let decoded_long_hex32 = Decode!(&Encode!(&long_hex32).unwrap(), Hex32);
+            for result in [decoded_short_hex32, decoded_long_hex32] {
+                prop_assert!(
+                    result.is_err(),
+                    "Expected error decoding hex32 with wrong length, got: {:?}",
+                    result
+                );
+            }
+        }
+    }
+
+    fn encode_decode_roundtrip<T>(value: &str) -> Result<(), TestCaseError>
+    where
+        T: FromStr + CandidType + DeserializeOwned + PartialEq + std::fmt::Debug,
+        <T as FromStr>::Err: std::fmt::Debug,
+    {
+        let hex: T = value.parse().unwrap();
+
+        let encoded_text_value = Encode!(&value.to_lowercase()).unwrap();
+        let encoded_hex = Encode!(&hex).unwrap();
+        prop_assert_eq!(
+            &encoded_text_value,
+            &encoded_hex,
+            "Encode value differ for {}",
+            value
+        );
+
+        let decoded_hex = Decode!(&encoded_text_value, T).unwrap();
+        prop_assert_eq!(&decoded_hex, &hex, "Decode value differ for {}", value);
+        Ok(())
+    }
+
+    fn arb_var_len_hex_string(
+        num_bytes_range: RangeInclusive<usize>,
+    ) -> impl Strategy<Value = String> {
+        num_bytes_range.prop_flat_map(|num_bytes| {
+            proptest::string::string_regex(&format!("0x[0-9a-fA-F]{{{}}}", 2 * num_bytes)).unwrap()
+        })
+    }
+}

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -6,8 +6,7 @@ use async_trait::async_trait;
 use candid::Nat;
 use cketh_common::{
     eth_rpc::{
-        into_nat, Block, Hash, ProviderError, RpcError, SendRawTransactionResult,
-        ValidationError,
+        into_nat, Block, Hash, ProviderError, RpcError, SendRawTransactionResult, ValidationError,
     },
     eth_rpc_client::{
         providers::{RpcApi, RpcService},

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use candid::Nat;
 use cketh_common::{
     eth_rpc::{
-        into_nat, Block, Hash, LogEntry, ProviderError, RpcError, SendRawTransactionResult,
+        into_nat, Block, Hash, ProviderError, RpcError, SendRawTransactionResult,
         ValidationError,
     },
     eth_rpc_client::{
@@ -184,8 +184,8 @@ impl CandidRpcClient {
     pub async fn eth_get_logs(
         &self,
         args: evm_rpc_types::GetLogsArgs,
-    ) -> MultiRpcResult<Vec<LogEntry>> {
-        use crate::candid_rpc::cketh_conversion::into_get_logs_param;
+    ) -> MultiRpcResult<Vec<evm_rpc_types::LogEntry>> {
+        use crate::candid_rpc::cketh_conversion::{from_log_entries, into_get_logs_param};
 
         if let (
             Some(evm_rpc_types::BlockTag::Number(from)),
@@ -207,6 +207,7 @@ impl CandidRpcClient {
             RpcMethod::EthGetLogs,
             self.client.eth_get_logs(into_get_logs_param(args)).await,
         )
+        .map(from_log_entries)
     }
 
     pub async fn eth_get_block_by_number(

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -1,6 +1,6 @@
 //! Conversion between ckETH types and EVM RPC types.
 //! This module is meant to be temporary and should be removed once the dependency on ckETH is removed,
-//! see https://github.com/internet-computer-protocol/evm-rpc-canister/issues/243
+//! see <https://github.com/internet-computer-protocol/evm-rpc-canister/issues/243>
 
 use cketh_common::checked_amount::CheckedAmountOf;
 use cketh_common::eth_rpc::Quantity;

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -18,6 +18,31 @@ pub(super) fn into_block_spec(value: BlockTag) -> cketh_common::eth_rpc::BlockSp
     }
 }
 
+pub(super) fn into_get_logs_param(
+    value: evm_rpc_types::GetLogsArgs,
+) -> cketh_common::eth_rpc::GetLogsParam {
+    cketh_common::eth_rpc::GetLogsParam {
+        from_block: value.from_block.map(into_block_spec).unwrap_or_default(),
+        to_block: value.to_block.map(into_block_spec).unwrap_or_default(),
+        address: value
+            .addresses
+            .into_iter()
+            .map(|address| cketh_common::address::Address::new(address.into()))
+            .collect(),
+        topics: value
+            .topics
+            .unwrap_or_default()
+            .into_iter()
+            .map(|topic| {
+                topic
+                    .into_iter()
+                    .map(|t| cketh_common::eth_rpc::FixedSizeData(t.into()))
+                    .collect()
+            })
+            .collect(),
+    }
+}
+
 pub(super) fn into_fee_history_params(
     value: evm_rpc_types::FeeHistoryArgs,
 ) -> cketh_common::eth_rpc::FeeHistoryParams {

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ use evm_rpc::{
 pub async fn eth_get_logs(
     source: RpcServices,
     config: Option<RpcConfig>,
-    args: candid_types::GetLogsArgs,
+    args: evm_rpc_types::GetLogsArgs,
 ) -> MultiRpcResult<Vec<LogEntry>> {
     match CandidRpcClient::new(source, config) {
         Ok(source) => source.eth_get_logs(args).await,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use candid::{candid_method, Principal};
-use cketh_common::eth_rpc::{Block, LogEntry, RpcError};
+use cketh_common::eth_rpc::{Block, RpcError};
 
 use cketh_common::eth_rpc_client::providers::RpcService;
 use cketh_common::eth_rpc_client::RpcConfig;
@@ -43,7 +43,7 @@ pub async fn eth_get_logs(
     source: RpcServices,
     config: Option<RpcConfig>,
     args: evm_rpc_types::GetLogsArgs,
-) -> MultiRpcResult<Vec<LogEntry>> {
+) -> MultiRpcResult<Vec<evm_rpc_types::LogEntry>> {
     match CandidRpcClient::new(source, config) {
         Ok(source) => source.eth_get_logs(args).await,
         Err(err) => Err(err).into(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -520,7 +520,7 @@ pub mod candid_types {
     use candid::CandidType;
     use cketh_common::{
         address::Address,
-        eth_rpc::{into_nat, FixedSizeData, ValidationError},
+        eth_rpc::{into_nat, ValidationError},
         numeric::BlockNumber,
     };
     use serde::Deserialize;
@@ -549,45 +549,6 @@ pub mod candid_types {
                 BlockTag::Earliest => BlockSpec::Tag(eth_rpc::BlockTag::Earliest),
                 BlockTag::Pending => BlockSpec::Tag(eth_rpc::BlockTag::Pending),
             }
-        }
-    }
-
-    #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize)]
-    pub struct GetLogsArgs {
-        #[serde(rename = "fromBlock")]
-        pub from_block: Option<BlockTag>,
-        #[serde(rename = "toBlock")]
-        pub to_block: Option<BlockTag>,
-        pub addresses: Vec<String>,
-        pub topics: Option<Vec<Vec<String>>>,
-    }
-
-    impl TryFrom<GetLogsArgs> for cketh_common::eth_rpc::GetLogsParam {
-        type Error = ValidationError;
-        fn try_from(value: GetLogsArgs) -> Result<Self, Self::Error> {
-            Ok(cketh_common::eth_rpc::GetLogsParam {
-                from_block: value.from_block.map(|x| x.into()).unwrap_or_default(),
-                to_block: value.to_block.map(|x| x.into()).unwrap_or_default(),
-                address: value
-                    .addresses
-                    .into_iter()
-                    .map(|s| Address::from_str(&s).map_err(|_| ValidationError::InvalidHex(s)))
-                    .collect::<Result<_, _>>()?,
-                topics: value
-                    .topics
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(|topic| {
-                        topic
-                            .into_iter()
-                            .map(|s| {
-                                FixedSizeData::from_str(&s)
-                                    .map_err(|_| ValidationError::InvalidHex(s))
-                            })
-                            .collect::<Result<_, _>>()
-                    })
-                    .collect::<Result<_, _>>()?,
-            })
         }
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,10 +7,7 @@ use candid::{CandidType, Decode, Encode, Nat, Principal};
 use cketh_common::{
     address::Address,
     checked_amount::CheckedAmountOf,
-    eth_rpc::{
-        Block, Data, FixedSizeData, Hash, HttpOutcallError, JsonRpcError, LogEntry, ProviderError,
-        RpcError,
-    },
+    eth_rpc::{Block, Hash, HttpOutcallError, JsonRpcError, ProviderError, RpcError},
     eth_rpc_client::{
         providers::{EthMainnetService, EthSepoliaService, RpcApi, RpcService},
         RpcConfig,
@@ -274,7 +271,7 @@ impl EvmRpcSetup {
         source: RpcServices,
         config: Option<RpcConfig>,
         args: evm_rpc_types::GetLogsArgs,
-    ) -> CallFlow<MultiRpcResult<Vec<LogEntry>>> {
+    ) -> CallFlow<MultiRpcResult<Vec<evm_rpc_types::LogEntry>>> {
         self.call_update("eth_getLogs", Encode!(&source, &config, &args).unwrap())
     }
 
@@ -1073,35 +1070,34 @@ fn eth_get_logs_should_succeed() {
         .unwrap();
         assert_eq!(
             response,
-            vec![LogEntry {
-                address: Address::from_str("0xdac17f958d2ee523a2206206994597c13d831ec7").unwrap(),
+            vec![evm_rpc_types::LogEntry {
+                address: "0xdac17f958d2ee523a2206206994597c13d831ec7"
+                    .parse()
+                    .unwrap(),
                 topics: vec![
                     "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
                     "0x000000000000000000000000a9d1e08c7793af67e9d92fe308d5697fb81d3e43",
                     "0x00000000000000000000000078cccfb3d517cd4ed6d045e263e134712288ace2"
                 ]
                 .into_iter()
-                .map(|hex| FixedSizeData::from_str(hex).unwrap())
+                .map(|hex| hex.parse().unwrap())
                 .collect(),
-                data: Data(
-                    hex::decode("000000000000000000000000000000000000000000000000000000003b9c6433")
+                data: "0x000000000000000000000000000000000000000000000000000000003b9c6433"
+                    .parse()
+                    .unwrap(),
+                block_number: Some(0x11dc77e_u32.into()),
+                transaction_hash: Some(
+                    "0xf3ed91a03ddf964281ac7a24351573efd535b80fc460a5c2ad2b9d23153ec678"
+                        .parse()
                         .unwrap()
                 ),
-                block_number: Some(CheckedAmountOf::new(0x11dc77e)),
-                transaction_hash: Some(
-                    Hash::from_str(
-                        "0xf3ed91a03ddf964281ac7a24351573efd535b80fc460a5c2ad2b9d23153ec678"
-                    )
-                    .unwrap()
-                ),
-                transaction_index: Some(CheckedAmountOf::new(0x65)),
+                transaction_index: Some(0x65_u32.into()),
                 block_hash: Some(
-                    Hash::from_str(
-                        "0xd5c72ad752b2f0144a878594faf8bd9f570f2f72af8e7f0940d3545a6388f629"
-                    )
-                    .unwrap()
+                    "0xd5c72ad752b2f0144a878594faf8bd9f570f2f72af8e7f0940d3545a6388f629"
+                        .parse()
+                        .unwrap()
                 ),
-                log_index: Some(CheckedAmountOf::new(0xe8)),
+                log_index: Some(0xe8_u32.into()),
                 removed: false
             }]
         );
@@ -1821,7 +1817,9 @@ fn should_use_custom_response_size_estimate() {
                 response_size_estimate: Some(max_response_bytes),
             }),
             evm_rpc_types::GetLogsArgs {
-                addresses: vec!["0xdAC17F958D2ee523a2206206994597C13D831ec7".parse().unwrap()],
+                addresses: vec!["0xdAC17F958D2ee523a2206206994597C13D831ec7"
+                    .parse()
+                    .unwrap()],
                 from_block: None,
                 to_block: None,
                 topics: None,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -273,7 +273,7 @@ impl EvmRpcSetup {
         &self,
         source: RpcServices,
         config: Option<RpcConfig>,
-        args: candid_types::GetLogsArgs,
+        args: evm_rpc_types::GetLogsArgs,
     ) -> CallFlow<MultiRpcResult<Vec<LogEntry>>> {
         self.call_update("eth_getLogs", Encode!(&source, &config, &args).unwrap())
     }
@@ -1060,8 +1060,8 @@ fn eth_get_logs_should_succeed() {
         .eth_get_logs(
             source.clone(),
             None,
-            candid_types::GetLogsArgs {
-                addresses: vec!["0xdAC17F958D2ee523a2206206994597C13D831ec7".to_string()],
+            evm_rpc_types::GetLogsArgs {
+                addresses: vec!["0xdAC17F958D2ee523a2206206994597C13D831ec7".parse().unwrap()],
                 from_block: None,
                 to_block: None,
                 topics: None,
@@ -1820,8 +1820,8 @@ fn should_use_custom_response_size_estimate() {
             Some(RpcConfig {
                 response_size_estimate: Some(max_response_bytes),
             }),
-            candid_types::GetLogsArgs {
-                addresses: vec!["0xdAC17F958D2ee523a2206206994597C13D831ec7".to_string()],
+            evm_rpc_types::GetLogsArgs {
+                addresses: vec!["0xdAC17F958D2ee523a2206206994597C13D831ec7".parse().unwrap()],
                 from_block: None,
                 to_block: None,
                 topics: None,


### PR DESCRIPTION
Follow-up on #257 to move the types `GetLogsArgs` and `LogEntry` to the `evm_rpc_types` crate, so that the public API of `eth_get_logs` only uses types from that crate.

Additionally, add the types `Hex`, `Hex20`, and `Hex32` as a transparent wrapper around a Candid type `text` to represent Ethereum hex strings (prefixed by `0x`) containing an unbounded, 20 or 32 bytes, respectively.
