### PR TITLE
refactor: move `GetTransactionCountArgs` and `SendRawTransactionStatus` to `evm_rpc_types`

### DIFF
--- a/evm_rpc_types/CHANGELOG.md
+++ b/evm_rpc_types/CHANGELOG.md
@@ -15,4 +15,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - v1.0 Move `BlockTag` to this crate.
 - v1.0 Move `FeeHistoryArgs` and `FeeHistory` to this crate.
 - v1.0 Move `GetLogsArgs` and `LogEntry` to this crate.
+- v1.0 Move `GetTransactionCountArgs` to this crate.
 - v1.0 Move `TransactionReceipt` to this crate.

--- a/evm_rpc_types/CHANGELOG.md
+++ b/evm_rpc_types/CHANGELOG.md
@@ -16,4 +16,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - v1.0 Move `FeeHistoryArgs` and `FeeHistory` to this crate.
 - v1.0 Move `GetLogsArgs` and `LogEntry` to this crate.
 - v1.0 Move `GetTransactionCountArgs` to this crate.
+- v1.0 Move `SendRawTransactionStatus` to this crate.
 - v1.0 Move `TransactionReceipt` to this crate.

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 mod request;
 mod response;
 
-pub use request::{FeeHistoryArgs, GetLogsArgs};
+pub use request::{FeeHistoryArgs, GetLogsArgs, GetTransactionCountArgs};
 pub use response::{Block, FeeHistory, LogEntry, TransactionReceipt};
 
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize, Default)]

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -13,7 +13,7 @@ mod request;
 mod response;
 
 pub use request::{FeeHistoryArgs, GetLogsArgs, GetTransactionCountArgs};
-pub use response::{Block, FeeHistory, LogEntry, TransactionReceipt};
+pub use response::{Block, FeeHistory, LogEntry, SendRawTransactionStatus, TransactionReceipt};
 
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize, Default)]
 pub enum BlockTag {
@@ -123,6 +123,12 @@ macro_rules! impl_hex_string {
         impl From<$name> for $data {
             fn from(value: $name) -> Self {
                 value.0
+            }
+        }
+
+        impl AsRef<[u8]> for $name {
+            fn as_ref(&self) -> &[u8] {
+                self.0.as_ref()
             }
         }
 

--- a/evm_rpc_types/src/request/mod.rs
+++ b/evm_rpc_types/src/request/mod.rs
@@ -40,3 +40,9 @@ pub struct GetLogsArgs {
     /// Each topic can also be an array of DATA with "or" options.
     pub topics: Option<Vec<Vec<Hex32>>>,
 }
+
+#[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize)]
+pub struct GetTransactionCountArgs {
+    pub address: Hex20,
+    pub block: BlockTag,
+}

--- a/evm_rpc_types/src/response/mod.rs
+++ b/evm_rpc_types/src/response/mod.rs
@@ -211,3 +211,11 @@ pub struct Block {
     #[serde(default)]
     pub uncles: Vec<Hex32>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, CandidType)]
+pub enum SendRawTransactionStatus {
+    Ok(Option<Hex32>),
+    InsufficientFunds,
+    NonceTooLow,
+    NonceTooHigh,
+}

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -3,7 +3,7 @@ mod cketh_conversion;
 use async_trait::async_trait;
 use candid::Nat;
 use cketh_common::{
-    eth_rpc::{Hash, ProviderError, SendRawTransactionResult, ValidationError},
+    eth_rpc::{ProviderError, ValidationError},
     eth_rpc_client::{
         providers::{RpcApi, RpcService},
         EthRpcClient as CkEthRpcClient, MultiCallError, RpcConfig, RpcTransport,
@@ -11,7 +11,7 @@ use cketh_common::{
     lifecycle::EthereumNetwork,
 };
 use ethers_core::{types::Transaction, utils::rlp};
-use evm_rpc_types::Hex32;
+use evm_rpc_types::{Hex, Hex32};
 use ic_cdk::api::management_canister::http_request::{CanisterHttpRequestArgument, HttpResponse};
 
 use crate::{
@@ -24,11 +24,9 @@ use crate::{
     http::http_request,
     providers::resolve_rpc_service,
     types::{
-        candid_types::{self, SendRawTransactionStatus},
         MetricRpcHost, MetricRpcMethod, MultiRpcResult, ResolvedRpcService, RpcMethod, RpcResult,
         RpcServices,
     },
-    util::hex_to_bytes,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -267,30 +265,23 @@ impl CandidRpcClient {
 
     pub async fn eth_send_raw_transaction(
         &self,
-        raw_signed_transaction_hex: String,
-    ) -> MultiRpcResult<candid_types::SendRawTransactionStatus> {
+        raw_signed_transaction_hex: Hex,
+    ) -> MultiRpcResult<evm_rpc_types::SendRawTransactionStatus> {
+        use crate::candid_rpc::cketh_conversion::from_send_raw_transaction_result;
         let transaction_hash = get_transaction_hash(&raw_signed_transaction_hex);
         process_result(
             RpcMethod::EthSendRawTransaction,
             self.client
-                .multi_eth_send_raw_transaction(raw_signed_transaction_hex)
+                .multi_eth_send_raw_transaction(raw_signed_transaction_hex.to_string())
                 .await,
         )
-        .map(|result| match result {
-            SendRawTransactionResult::Ok => SendRawTransactionStatus::Ok(transaction_hash),
-            SendRawTransactionResult::InsufficientFunds => {
-                SendRawTransactionStatus::InsufficientFunds
-            }
-            SendRawTransactionResult::NonceTooLow => SendRawTransactionStatus::NonceTooLow,
-            SendRawTransactionResult::NonceTooHigh => SendRawTransactionStatus::NonceTooHigh,
-        })
+        .map(|result| from_send_raw_transaction_result(transaction_hash.clone(), result))
     }
 }
 
-fn get_transaction_hash(raw_signed_transaction_hex: &str) -> Option<Hash> {
-    let bytes = hex_to_bytes(raw_signed_transaction_hex)?;
-    let transaction: Transaction = rlp::decode(&bytes).ok()?;
-    Some(Hash(transaction.hash.0))
+fn get_transaction_hash(raw_signed_transaction_hex: &Hex) -> Option<Hex32> {
+    let transaction: Transaction = rlp::decode(raw_signed_transaction_hex.as_ref()).ok()?;
+    Some(Hex32::from(transaction.hash.0))
 }
 
 #[cfg(test)]

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -166,6 +166,26 @@ pub(super) fn from_block(value: cketh_common::eth_rpc::Block) -> evm_rpc_types::
     }
 }
 
+pub(super) fn from_send_raw_transaction_result(
+    transaction_hash: Option<Hex32>,
+    value: cketh_common::eth_rpc::SendRawTransactionResult,
+) -> evm_rpc_types::SendRawTransactionStatus {
+    match value {
+        cketh_common::eth_rpc::SendRawTransactionResult::Ok => {
+            evm_rpc_types::SendRawTransactionStatus::Ok(transaction_hash)
+        }
+        cketh_common::eth_rpc::SendRawTransactionResult::InsufficientFunds => {
+            evm_rpc_types::SendRawTransactionStatus::InsufficientFunds
+        }
+        cketh_common::eth_rpc::SendRawTransactionResult::NonceTooLow => {
+            evm_rpc_types::SendRawTransactionStatus::NonceTooLow
+        }
+        cketh_common::eth_rpc::SendRawTransactionResult::NonceTooHigh => {
+            evm_rpc_types::SendRawTransactionStatus::NonceTooHigh
+        }
+    }
+}
+
 pub(super) fn into_hash(value: Hex32) -> Hash {
     Hash(value.into())
 }

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -92,6 +92,15 @@ pub(super) fn from_fee_history(
     }
 }
 
+pub(super) fn into_get_transaction_count_params(
+    value: evm_rpc_types::GetTransactionCountArgs,
+) -> cketh_common::eth_rpc_client::requests::GetTransactionCountParams {
+    cketh_common::eth_rpc_client::requests::GetTransactionCountParams {
+        address: cketh_common::address::Address::new(value.address.into()),
+        block: into_block_spec(value.block),
+    }
+}
+
 pub(super) fn from_transaction_receipt(
     value: cketh_common::eth_rpc_client::responses::TransactionReceipt,
 ) -> evm_rpc_types::TransactionReceipt {
@@ -165,7 +174,7 @@ fn into_checked_amount_of<Unit>(value: Nat256) -> CheckedAmountOf<Unit> {
     CheckedAmountOf::from_be_bytes(value.into_be_bytes())
 }
 
-fn from_checked_amount_of<Unit>(value: CheckedAmountOf<Unit>) -> Nat256 {
+pub(super) fn from_checked_amount_of<Unit>(value: CheckedAmountOf<Unit>) -> Nat256 {
     Nat256::from_be_bytes(value.to_be_bytes())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,8 +83,8 @@ pub async fn eth_get_transaction_receipt(
 pub async fn eth_get_transaction_count(
     source: RpcServices,
     config: Option<RpcConfig>,
-    args: candid_types::GetTransactionCountArgs,
-) -> MultiRpcResult<candid::Nat> {
+    args: evm_rpc_types::GetTransactionCountArgs,
+) -> MultiRpcResult<evm_rpc_types::Nat256> {
     match CandidRpcClient::new(source, config) {
         Ok(source) => source.eth_get_transaction_count(args).await,
         Err(err) => Err(err).into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use ic_nervous_system_common::serve_metrics;
 use evm_rpc::{
     http::{json_rpc_request, transform_http_request},
     memory::UNSTABLE_METRICS,
-    types::{candid_types, InitArgs, MetricRpcMethod, Metrics, MultiRpcResult, RpcServices},
+    types::{InitArgs, MetricRpcMethod, Metrics, MultiRpcResult, RpcServices},
 };
 use evm_rpc_types::Hex32;
 
@@ -109,8 +109,8 @@ pub async fn eth_fee_history(
 pub async fn eth_send_raw_transaction(
     source: RpcServices,
     config: Option<RpcConfig>,
-    raw_signed_transaction_hex: String,
-) -> MultiRpcResult<candid_types::SendRawTransactionStatus> {
+    raw_signed_transaction_hex: evm_rpc_types::Hex,
+) -> MultiRpcResult<evm_rpc_types::SendRawTransactionStatus> {
     match CandidRpcClient::new(source, config) {
         Ok(source) => {
             source

--- a/src/types.rs
+++ b/src/types.rs
@@ -444,10 +444,8 @@ pub enum RpcServices {
 }
 
 pub mod candid_types {
-    use std::str::FromStr;
-
     use candid::CandidType;
-    use cketh_common::{address::Address, eth_rpc::ValidationError, numeric::BlockNumber};
+    use cketh_common::numeric::BlockNumber;
     use serde::Deserialize;
 
     pub use cketh_common::eth_rpc::Hash;
@@ -474,27 +472,6 @@ pub mod candid_types {
                 BlockTag::Earliest => BlockSpec::Tag(eth_rpc::BlockTag::Earliest),
                 BlockTag::Pending => BlockSpec::Tag(eth_rpc::BlockTag::Pending),
             }
-        }
-    }
-
-    #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize)]
-    pub struct GetTransactionCountArgs {
-        pub address: String,
-        pub block: BlockTag,
-    }
-
-    impl TryFrom<GetTransactionCountArgs>
-        for cketh_common::eth_rpc_client::requests::GetTransactionCountParams
-    {
-        type Error = ValidationError;
-        fn try_from(value: GetTransactionCountArgs) -> Result<Self, Self::Error> {
-            Ok(
-                cketh_common::eth_rpc_client::requests::GetTransactionCountParams {
-                    address: Address::from_str(&value.address)
-                        .map_err(|_| ValidationError::InvalidHex(value.address))?,
-                    block: value.block.into(),
-                },
-            )
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -443,47 +443,6 @@ pub enum RpcServices {
     OptimismMainnet(Option<Vec<L2MainnetService>>),
 }
 
-pub mod candid_types {
-    use candid::CandidType;
-    use cketh_common::numeric::BlockNumber;
-    use serde::Deserialize;
-
-    pub use cketh_common::eth_rpc::Hash;
-
-    #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize, Default)]
-    pub enum BlockTag {
-        #[default]
-        Latest,
-        Finalized,
-        Safe,
-        Earliest,
-        Pending,
-        Number(BlockNumber),
-    }
-
-    impl From<BlockTag> for cketh_common::eth_rpc::BlockSpec {
-        fn from(value: BlockTag) -> Self {
-            use cketh_common::eth_rpc::{self, BlockSpec};
-            match value {
-                BlockTag::Number(n) => BlockSpec::Number(n),
-                BlockTag::Latest => BlockSpec::Tag(eth_rpc::BlockTag::Latest),
-                BlockTag::Safe => BlockSpec::Tag(eth_rpc::BlockTag::Safe),
-                BlockTag::Finalized => BlockSpec::Tag(eth_rpc::BlockTag::Finalized),
-                BlockTag::Earliest => BlockSpec::Tag(eth_rpc::BlockTag::Earliest),
-                BlockTag::Pending => BlockSpec::Tag(eth_rpc::BlockTag::Pending),
-            }
-        }
-    }
-
-    #[derive(Debug, Clone, PartialEq, Eq, CandidType, Deserialize)]
-    pub enum SendRawTransactionStatus {
-        Ok(Option<Hash>),
-        InsufficientFunds,
-        NonceTooLow,
-        NonceTooHigh,
-    }
-}
-
 #[cfg(test)]
 mod test {
     use cketh_common::{

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -254,8 +254,8 @@ impl EvmRpcSetup {
         &self,
         source: RpcServices,
         config: Option<RpcConfig>,
-        args: candid_types::GetTransactionCountArgs,
-    ) -> CallFlow<MultiRpcResult<Nat>> {
+        args: evm_rpc_types::GetTransactionCountArgs,
+    ) -> CallFlow<MultiRpcResult<Nat256>> {
         self.call_update(
             "eth_getTransactionCount",
             Encode!(&source, &config, &args).unwrap(),
@@ -645,9 +645,11 @@ fn should_use_fallback_public_url() {
         .eth_get_transaction_count(
             RpcServices::EthMainnet(Some(vec![EthMainnetService::Ankr])),
             None,
-            candid_types::GetTransactionCountArgs {
-                address: "0xdAC17F958D2ee523a2206206994597C13D831ec7".to_string(),
-                block: candid_types::BlockTag::Latest,
+            evm_rpc_types::GetTransactionCountArgs {
+                address: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+                    .parse()
+                    .unwrap(),
+                block: evm_rpc_types::BlockTag::Latest,
             },
         )
         .mock_http(
@@ -657,7 +659,7 @@ fn should_use_fallback_public_url() {
         .wait()
         .expect_consistent()
         .unwrap();
-    assert_eq!(response, 1);
+    assert_eq!(response, 1_u8.into());
 }
 
 #[test]
@@ -676,9 +678,11 @@ fn should_insert_api_keys() {
         .eth_get_transaction_count(
             RpcServices::EthMainnet(Some(vec![EthMainnetService::Ankr])),
             None,
-            candid_types::GetTransactionCountArgs {
-                address: "0xdAC17F958D2ee523a2206206994597C13D831ec7".to_string(),
-                block: candid_types::BlockTag::Latest,
+            evm_rpc_types::GetTransactionCountArgs {
+                address: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+                    .parse()
+                    .unwrap(),
+                block: evm_rpc_types::BlockTag::Latest,
             },
         )
         .mock_http(
@@ -688,7 +692,7 @@ fn should_insert_api_keys() {
         .wait()
         .expect_consistent()
         .unwrap();
-    assert_eq!(response, 1);
+    assert_eq!(response, 1_u8.into());
 }
 
 #[test]
@@ -882,9 +886,11 @@ fn eth_get_transaction_count_should_succeed() {
             .eth_get_transaction_count(
                 source.clone(),
                 None,
-                candid_types::GetTransactionCountArgs {
-                    address: "0xdAC17F958D2ee523a2206206994597C13D831ec7".to_string(),
-                    block: candid_types::BlockTag::Latest,
+                evm_rpc_types::GetTransactionCountArgs {
+                    address: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+                        .parse()
+                        .unwrap(),
+                    block: evm_rpc_types::BlockTag::Latest,
                 },
             )
             .mock_http(MockOutcallBuilder::new(
@@ -894,7 +900,7 @@ fn eth_get_transaction_count_should_succeed() {
             .wait()
             .expect_consistent()
             .unwrap();
-        assert_eq!(response, 1);
+        assert_eq!(response, 1_u8.into());
     }
 }
 
@@ -1170,9 +1176,11 @@ fn candid_rpc_should_return_inconsistent_results_with_error() {
                 EthMainnetService::Ankr,
             ])),
             None,
-            candid_types::GetTransactionCountArgs {
-                address: "0xdAC17F958D2ee523a2206206994597C13D831ec7".to_string(),
-                block: candid_types::BlockTag::Latest,
+            evm_rpc_types::GetTransactionCountArgs {
+                address: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+                    .parse()
+                    .unwrap(),
+                block: evm_rpc_types::BlockTag::Latest,
             },
         )
         .mock_http_once(MockOutcallBuilder::new(
@@ -1190,7 +1198,7 @@ fn candid_rpc_should_return_inconsistent_results_with_error() {
         vec![
             (
                 RpcService::EthMainnet(EthMainnetService::Alchemy),
-                Ok(1.into())
+                Ok(1_u8.into())
             ),
             (
                 RpcService::EthMainnet(EthMainnetService::Ankr),
@@ -1232,9 +1240,11 @@ fn candid_rpc_should_return_inconsistent_results_with_unexpected_http_status() {
                 EthMainnetService::Ankr,
             ])),
             None,
-            candid_types::GetTransactionCountArgs {
-                address: "0xdAC17F958D2ee523a2206206994597C13D831ec7".to_string(),
-                block: candid_types::BlockTag::Latest,
+            evm_rpc_types::GetTransactionCountArgs {
+                address: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+                    .parse()
+                    .unwrap(),
+                block: evm_rpc_types::BlockTag::Latest,
             },
         )
         .mock_http_once(MockOutcallBuilder::new(
@@ -1252,7 +1262,7 @@ fn candid_rpc_should_return_inconsistent_results_with_unexpected_http_status() {
         vec![
             (
                 RpcService::EthMainnet(EthMainnetService::Alchemy),
-                Ok(1.into())
+                Ok(1_u8.into())
             ),
             (
                 RpcService::EthMainnet(EthMainnetService::Ankr),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -6,7 +6,7 @@ use assert_matches::assert_matches;
 use candid::{CandidType, Decode, Encode, Nat};
 use cketh_common::{
     address::Address,
-    eth_rpc::{Hash, HttpOutcallError, JsonRpcError, ProviderError, RpcError},
+    eth_rpc::{HttpOutcallError, JsonRpcError, ProviderError, RpcError},
     eth_rpc_client::{
         providers::{EthMainnetService, EthSepoliaService, RpcApi, RpcService},
         RpcConfig,
@@ -31,11 +31,10 @@ use evm_rpc::{
     constants::{CONTENT_TYPE_HEADER_LOWERCASE, CONTENT_TYPE_VALUE},
     providers::PROVIDERS,
     types::{
-        candid_types, InitArgs, Metrics, MultiRpcResult, ProviderId, RpcAccess, RpcMethod,
-        RpcResult, RpcServices,
+        InitArgs, Metrics, MultiRpcResult, ProviderId, RpcAccess, RpcMethod, RpcResult, RpcServices,
     },
 };
-use evm_rpc_types::Nat256;
+use evm_rpc_types::{Hex, Hex32, Nat256};
 use mock::{MockOutcall, MockOutcallBuilder};
 
 const DEFAULT_CALLER_TEST_ID: u64 = 10352385;
@@ -276,7 +275,8 @@ impl EvmRpcSetup {
         source: RpcServices,
         config: Option<RpcConfig>,
         signed_raw_transaction_hex: &str,
-    ) -> CallFlow<MultiRpcResult<candid_types::SendRawTransactionStatus>> {
+    ) -> CallFlow<MultiRpcResult<evm_rpc_types::SendRawTransactionStatus>> {
+        let signed_raw_transaction_hex: Hex = signed_raw_transaction_hex.parse().unwrap();
         self.call_update(
             "eth_sendRawTransaction",
             Encode!(&source, &config, &signed_raw_transaction_hex).unwrap(),
@@ -955,8 +955,8 @@ fn eth_send_raw_transaction_should_succeed() {
             .unwrap();
         assert_eq!(
             response,
-            candid_types::SendRawTransactionStatus::Ok(Some(
-                Hash::from_str(MOCK_TRANSACTION_HASH).unwrap()
+            evm_rpc_types::SendRawTransactionStatus::Ok(Some(
+                Hex32::from_str(MOCK_TRANSACTION_HASH).unwrap()
             ))
         );
     }
@@ -1135,13 +1135,13 @@ fn candid_rpc_should_return_inconsistent_results() {
         vec![
             (
                 RpcService::EthMainnet(EthMainnetService::Ankr),
-                Ok(candid_types::SendRawTransactionStatus::Ok(Some(
-                    Hash::from_str(MOCK_TRANSACTION_HASH).unwrap()
+                Ok(evm_rpc_types::SendRawTransactionStatus::Ok(Some(
+                    Hex32::from_str(MOCK_TRANSACTION_HASH).unwrap()
                 )))
             ),
             (
                 RpcService::EthMainnet(EthMainnetService::Cloudflare),
-                Ok(candid_types::SendRawTransactionStatus::NonceTooLow)
+                Ok(evm_rpc_types::SendRawTransactionStatus::NonceTooLow)
             )
         ]
     );
@@ -1319,8 +1319,8 @@ fn candid_rpc_should_handle_already_known() {
         .expect_consistent();
     assert_eq!(
         result,
-        Ok(candid_types::SendRawTransactionStatus::Ok(Some(
-            Hash::from_str(MOCK_TRANSACTION_HASH).unwrap()
+        Ok(evm_rpc_types::SendRawTransactionStatus::Ok(Some(
+            Hex32::from_str(MOCK_TRANSACTION_HASH).unwrap()
         )))
     );
     let rpc_method = || RpcMethod::EthSendRawTransaction.into();


### PR DESCRIPTION
Follow-up on #257  to move the types `GetTransactionCountArgs` and `SendRawTransactionStatus` to the `evm_rpc_types` crate, so that the public API of `eth_get_transaction_count` and `eth_send_raw_transaction`, respectively,  only uses types from that crate.