### PR TITLE
refactor: move types related to providers to `evm-rpc-types` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,6 +1629,7 @@ version = "0.1.0"
 dependencies = [
  "candid",
  "hex",
+ "ic-cdk",
  "num-bigint 0.4.6",
  "proptest",
  "serde",

--- a/evm_rpc_types/CHANGELOG.md
+++ b/evm_rpc_types/CHANGELOG.md
@@ -16,5 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - v1.0 Move `FeeHistoryArgs` and `FeeHistory` to this crate.
 - v1.0 Move `GetLogsArgs` and `LogEntry` to this crate.
 - v1.0 Move `GetTransactionCountArgs` to this crate.
+- v1.0 Move `RpcConfig` to this crate.
 - v1.0 Move `SendRawTransactionStatus` to this crate.
 - v1.0 Move `TransactionReceipt` to this crate.

--- a/evm_rpc_types/CHANGELOG.md
+++ b/evm_rpc_types/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - v1.0 `Nat256`: transparent wrapper around a `Nat` to guarantee that it fits in 256 bits.
-- v1.0 `HexByte`, `Hex20`, `Hex32`, `Hex256` and `Hex` : Candid types wrapping an amount of bytes (`u8` for `HexByte`, `[u8; N]` for `HexN`, and `Vec<u8>` for `Hex`) that can be represented as an hexadecimal string (prefixed by `0x`) when serialized.
+- v1.0 `HexByte`, `Hex20`, `Hex32`, `Hex256` and `Hex` : Candid types wrapping an amount of bytes (`u8` for `HexByte`,
+  `[u8; N]` for `HexN`, and `Vec<u8>` for `Hex`) that can be represented as an hexadecimal string (prefixed by `0x`)
+  when serialized.
 - v1.0 Move `Block` to this crate.
 - v1.0 Move `BlockTag` to this crate.
 - v1.0 Move `FeeHistoryArgs` and `FeeHistory` to this crate.
@@ -19,3 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - v1.0 Move `RpcConfig` to this crate.
 - v1.0 Move `SendRawTransactionStatus` to this crate.
 - v1.0 Move `TransactionReceipt` to this crate.
+- v1.0 Move providers-related struct `EthMainnetService`, `EthSepoliaService`, `HttpHeader`, `L2MainnetService`,
+  `RpcApi`, `RpcConfig`,
+  `RpcService`, `RpcServices` to this crate.

--- a/evm_rpc_types/Cargo.toml
+++ b/evm_rpc_types/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 [dependencies]
 candid = { workspace = true }
 hex = { workspace = true }
+ic-cdk = { workspace = true }
 num-bigint = { workspace = true }
 serde = { workspace = true }
 

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -11,9 +11,11 @@ use std::str::FromStr;
 
 mod request;
 mod response;
+mod rpc_client;
 
 pub use request::{FeeHistoryArgs, GetLogsArgs, GetTransactionCountArgs};
 pub use response::{Block, FeeHistory, LogEntry, SendRawTransactionStatus, TransactionReceipt};
+pub use rpc_client::RpcConfig;
 
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize, Default)]
 pub enum BlockTag {

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -15,7 +15,10 @@ mod rpc_client;
 
 pub use request::{FeeHistoryArgs, GetLogsArgs, GetTransactionCountArgs};
 pub use response::{Block, FeeHistory, LogEntry, SendRawTransactionStatus, TransactionReceipt};
-pub use rpc_client::RpcConfig;
+pub use rpc_client::{
+    EthMainnetService, EthSepoliaService, HttpHeader, L2MainnetService, RpcApi, RpcConfig,
+    RpcService, RpcServices,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize, Default)]
 pub enum BlockTag {

--- a/evm_rpc_types/src/rpc_client/mod.rs
+++ b/evm_rpc_types/src/rpc_client/mod.rs
@@ -1,0 +1,7 @@
+use candid::{CandidType, Deserialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, Default, CandidType, Deserialize)]
+pub struct RpcConfig {
+    #[serde(rename = "responseSizeEstimate")]
+    pub response_size_estimate: Option<u64>,
+}

--- a/evm_rpc_types/src/rpc_client/mod.rs
+++ b/evm_rpc_types/src/rpc_client/mod.rs
@@ -1,7 +1,91 @@
+pub use ic_cdk::api::management_canister::http_request::HttpHeader;
+
 use candid::{CandidType, Deserialize};
+use serde::Serialize;
 
 #[derive(Clone, Debug, PartialEq, Eq, Default, CandidType, Deserialize)]
 pub struct RpcConfig {
     #[serde(rename = "responseSizeEstimate")]
     pub response_size_estimate: Option<u64>,
+}
+
+#[derive(Clone, CandidType, Deserialize)]
+pub enum RpcServices {
+    Custom {
+        #[serde(rename = "chainId")]
+        chain_id: u64,
+        services: Vec<RpcApi>,
+    },
+    EthMainnet(Option<Vec<EthMainnetService>>),
+    EthSepolia(Option<Vec<EthSepoliaService>>),
+    ArbitrumOne(Option<Vec<L2MainnetService>>),
+    BaseMainnet(Option<Vec<L2MainnetService>>),
+    OptimismMainnet(Option<Vec<L2MainnetService>>),
+}
+
+#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize, CandidType)]
+pub struct RpcApi {
+    pub url: String,
+    pub headers: Option<Vec<HttpHeader>>,
+}
+
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize, CandidType,
+)]
+pub enum EthMainnetService {
+    Alchemy,
+    Ankr,
+    BlockPi,
+    PublicNode,
+    Cloudflare,
+    Llama,
+}
+
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize, CandidType,
+)]
+pub enum EthSepoliaService {
+    Alchemy,
+    Ankr,
+    BlockPi,
+    PublicNode,
+    Sepolia,
+}
+
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize, CandidType,
+)]
+pub enum L2MainnetService {
+    Alchemy,
+    Ankr,
+    BlockPi,
+    PublicNode,
+    Llama,
+}
+
+#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize, CandidType)]
+pub enum RpcService {
+    Chain(u64),
+    Provider(u64),
+    Custom(RpcApi),
+    EthMainnet(EthMainnetService),
+    EthSepolia(EthSepoliaService),
+    ArbitrumOne(L2MainnetService),
+    BaseMainnet(L2MainnetService),
+    OptimismMainnet(L2MainnetService),
+}
+
+impl std::fmt::Debug for RpcService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RpcService::Chain(chain_id) => write!(f, "Chain({})", chain_id),
+            RpcService::Provider(provider_id) => write!(f, "Provider({})", provider_id),
+            RpcService::Custom(_) => write!(f, "Custom(..)"), // Redact credentials
+            RpcService::EthMainnet(service) => write!(f, "{:?}", service),
+            RpcService::EthSepolia(service) => write!(f, "{:?}", service),
+            RpcService::ArbitrumOne(service)
+            | RpcService::BaseMainnet(service)
+            | RpcService::OptimismMainnet(service) => write!(f, "{:?}", service),
+        }
+    }
 }

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -4,14 +4,10 @@ use async_trait::async_trait;
 use candid::Nat;
 use cketh_common::{
     eth_rpc::{ProviderError, ValidationError},
-    eth_rpc_client::{
-        providers::{RpcApi, RpcService},
-        EthRpcClient as CkEthRpcClient, MultiCallError, RpcTransport,
-    },
-    lifecycle::EthereumNetwork,
+    eth_rpc_client::{EthRpcClient as CkEthRpcClient, MultiCallError, RpcTransport},
 };
 use ethers_core::{types::Transaction, utils::rlp};
-use evm_rpc_types::{Hex, Hex32};
+use evm_rpc_types::{Hex, Hex32, RpcServices};
 use ic_cdk::api::management_canister::http_request::{CanisterHttpRequestArgument, HttpResponse};
 
 use crate::{
@@ -25,7 +21,6 @@ use crate::{
     providers::resolve_rpc_service,
     types::{
         MetricRpcHost, MetricRpcMethod, MultiRpcResult, ResolvedRpcService, RpcMethod, RpcResult,
-        RpcServices,
     },
 };
 
@@ -35,17 +30,23 @@ struct CanisterTransport;
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl RpcTransport for CanisterTransport {
-    fn resolve_api(service: &RpcService) -> Result<RpcApi, ProviderError> {
-        Ok(resolve_rpc_service(service.clone())?.api())
+    fn resolve_api(
+        service: &cketh_common::eth_rpc_client::providers::RpcService,
+    ) -> Result<cketh_common::eth_rpc_client::providers::RpcApi, ProviderError> {
+        use crate::candid_rpc::cketh_conversion::{from_rpc_service, into_rpc_api};
+        Ok(into_rpc_api(
+            resolve_rpc_service(from_rpc_service(service.clone()))?.api(),
+        ))
     }
 
     async fn http_request(
-        service: &RpcService,
+        service: &cketh_common::eth_rpc_client::providers::RpcService,
         method: &str,
         request: CanisterHttpRequestArgument,
         effective_response_size_estimate: u64,
     ) -> RpcResult<HttpResponse> {
-        let service = resolve_rpc_service(service.clone())?;
+        use crate::candid_rpc::cketh_conversion::from_rpc_service;
+        let service = resolve_rpc_service(from_rpc_service(service.clone()))?;
         let cycles_cost = get_http_request_cost(
             request
                 .body
@@ -70,74 +71,23 @@ fn get_rpc_client(
     source: RpcServices,
     config: evm_rpc_types::RpcConfig,
 ) -> RpcResult<CkEthRpcClient<CanisterTransport>> {
-    use crate::candid_rpc::cketh_conversion::into_rpc_config;
+    use crate::candid_rpc::cketh_conversion::{
+        into_ethereum_network, into_rpc_config, into_rpc_services,
+    };
 
     let config = into_rpc_config(config);
-    Ok(match source {
-        RpcServices::Custom { chain_id, services } => CkEthRpcClient::new(
-            EthereumNetwork(chain_id),
-            Some(
-                check_services(services)?
-                    .into_iter()
-                    .map(RpcService::Custom)
-                    .collect(),
-            ),
-            config,
-        ),
-        RpcServices::EthMainnet(services) => CkEthRpcClient::new(
-            EthereumNetwork::MAINNET,
-            Some(
-                check_services(services.unwrap_or_else(|| DEFAULT_ETH_MAINNET_SERVICES.to_vec()))?
-                    .into_iter()
-                    .map(RpcService::EthMainnet)
-                    .collect(),
-            ),
-            config,
-        ),
-        RpcServices::EthSepolia(services) => CkEthRpcClient::new(
-            EthereumNetwork::SEPOLIA,
-            Some(
-                check_services(services.unwrap_or_else(|| DEFAULT_ETH_SEPOLIA_SERVICES.to_vec()))?
-                    .into_iter()
-                    .map(RpcService::EthSepolia)
-                    .collect(),
-            ),
-            config,
-        ),
-        RpcServices::ArbitrumOne(services) => CkEthRpcClient::new(
-            EthereumNetwork::ARBITRUM,
-            Some(
-                check_services(services.unwrap_or_else(|| DEFAULT_L2_MAINNET_SERVICES.to_vec()))?
-                    .into_iter()
-                    .map(RpcService::ArbitrumOne)
-                    .collect(),
-            ),
-            config,
-        ),
-        RpcServices::BaseMainnet(services) => CkEthRpcClient::new(
-            EthereumNetwork::BASE,
-            Some(
-                check_services(services.unwrap_or_else(|| DEFAULT_L2_MAINNET_SERVICES.to_vec()))?
-                    .into_iter()
-                    .map(RpcService::BaseMainnet)
-                    .collect(),
-            ),
-            config,
-        ),
-        RpcServices::OptimismMainnet(services) => CkEthRpcClient::new(
-            EthereumNetwork::OPTIMISM,
-            Some(
-                check_services(services.unwrap_or_else(|| DEFAULT_L2_MAINNET_SERVICES.to_vec()))?
-                    .into_iter()
-                    .map(RpcService::OptimismMainnet)
-                    .collect(),
-            ),
-            config,
-        ),
-    })
+    let chain = into_ethereum_network(&source);
+    let providers = check_services(into_rpc_services(
+        source,
+        DEFAULT_ETH_MAINNET_SERVICES,
+        DEFAULT_ETH_SEPOLIA_SERVICES,
+        DEFAULT_L2_MAINNET_SERVICES,
+    ))?;
+    Ok(CkEthRpcClient::new(chain, Some(providers), config))
 }
 
 fn process_result<T>(method: RpcMethod, result: Result<T, MultiCallError<T>>) -> MultiRpcResult<T> {
+    use crate::candid_rpc::cketh_conversion::from_rpc_service;
     match result {
         Ok(value) => MultiRpcResult::Consistent(Ok(value)),
         Err(err) => match err {
@@ -145,7 +95,7 @@ fn process_result<T>(method: RpcMethod, result: Result<T, MultiCallError<T>>) ->
             MultiCallError::InconsistentResults(multi_call_results) => {
                 multi_call_results.results.iter().for_each(|(service, _)| {
                     if let Ok(ResolvedRpcService::Provider(provider)) =
-                        resolve_rpc_service(service.clone())
+                        resolve_rpc_service(from_rpc_service(service.clone()))
                     {
                         add_metric_entry!(
                             inconsistent_responses,
@@ -161,7 +111,13 @@ fn process_result<T>(method: RpcMethod, result: Result<T, MultiCallError<T>>) ->
                         )
                     }
                 });
-                MultiRpcResult::Inconsistent(multi_call_results.results.into_iter().collect())
+                MultiRpcResult::Inconsistent(
+                    multi_call_results
+                        .results
+                        .into_iter()
+                        .map(|(service, result)| (from_rpc_service(service), result))
+                        .collect(),
+                )
             }
         },
     }
@@ -172,7 +128,10 @@ pub struct CandidRpcClient {
 }
 
 impl CandidRpcClient {
-    pub fn new(source: RpcServices, config: Option<evm_rpc_types::RpcConfig>) -> RpcResult<Self> {
+    pub fn new(
+        source: evm_rpc_types::RpcServices,
+        config: Option<evm_rpc_types::RpcConfig>,
+    ) -> RpcResult<Self> {
         Ok(Self {
             client: get_rpc_client(source, config.unwrap_or_default())?,
         })
@@ -290,11 +249,13 @@ fn get_transaction_hash(raw_signed_transaction_hex: &Hex) -> Option<Hex32> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::candid_rpc::cketh_conversion::into_rpc_service;
     use cketh_common::eth_rpc::RpcError;
 
     #[test]
     fn test_process_result_mapping() {
-        use cketh_common::eth_rpc_client::{providers::EthMainnetService, MultiCallResults};
+        use cketh_common::eth_rpc_client::MultiCallResults;
+        use evm_rpc_types::{EthMainnetService, RpcService};
 
         let method = RpcMethod::EthGetTransactionCount;
 
@@ -328,9 +289,12 @@ mod test {
             process_result(
                 method,
                 Err(MultiCallError::InconsistentResults(MultiCallResults {
-                    results: vec![(RpcService::EthMainnet(EthMainnetService::Ankr), Ok(5))]
-                        .into_iter()
-                        .collect(),
+                    results: vec![(
+                        into_rpc_service(RpcService::EthMainnet(EthMainnetService::Ankr)),
+                        Ok(5)
+                    )]
+                    .into_iter()
+                    .collect(),
                 }))
             ),
             MultiRpcResult::Inconsistent(vec![(
@@ -343,9 +307,12 @@ mod test {
                 method,
                 Err(MultiCallError::InconsistentResults(MultiCallResults {
                     results: vec![
-                        (RpcService::EthMainnet(EthMainnetService::Ankr), Ok(5)),
                         (
-                            RpcService::EthMainnet(EthMainnetService::Cloudflare),
+                            into_rpc_service(RpcService::EthMainnet(EthMainnetService::Ankr)),
+                            Ok(5)
+                        ),
+                        (
+                            into_rpc_service(RpcService::EthMainnet(EthMainnetService::Cloudflare)),
                             Err(RpcError::ProviderError(ProviderError::NoPermission))
                         )
                     ]

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -6,7 +6,7 @@ use cketh_common::{
     eth_rpc::{ProviderError, ValidationError},
     eth_rpc_client::{
         providers::{RpcApi, RpcService},
-        EthRpcClient as CkEthRpcClient, MultiCallError, RpcConfig, RpcTransport,
+        EthRpcClient as CkEthRpcClient, MultiCallError, RpcTransport,
     },
     lifecycle::EthereumNetwork,
 };
@@ -68,8 +68,11 @@ fn check_services<T>(services: Vec<T>) -> RpcResult<Vec<T>> {
 
 fn get_rpc_client(
     source: RpcServices,
-    config: RpcConfig,
+    config: evm_rpc_types::RpcConfig,
 ) -> RpcResult<CkEthRpcClient<CanisterTransport>> {
+    use crate::candid_rpc::cketh_conversion::into_rpc_config;
+
+    let config = into_rpc_config(config);
     Ok(match source {
         RpcServices::Custom { chain_id, services } => CkEthRpcClient::new(
             EthereumNetwork(chain_id),
@@ -169,7 +172,7 @@ pub struct CandidRpcClient {
 }
 
 impl CandidRpcClient {
-    pub fn new(source: RpcServices, config: Option<RpcConfig>) -> RpcResult<Self> {
+    pub fn new(source: RpcServices, config: Option<evm_rpc_types::RpcConfig>) -> RpcResult<Self> {
         Ok(Self {
             client: get_rpc_client(source, config.unwrap_or_default())?,
         })

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -194,6 +194,399 @@ pub(super) fn into_rpc_config(
     }
 }
 
+pub(super) fn into_ethereum_network(
+    source: &evm_rpc_types::RpcServices,
+) -> cketh_common::lifecycle::EthereumNetwork {
+    match &source {
+        evm_rpc_types::RpcServices::Custom { chain_id, .. } => {
+            cketh_common::lifecycle::EthereumNetwork(*chain_id)
+        }
+        evm_rpc_types::RpcServices::EthMainnet(_) => {
+            cketh_common::lifecycle::EthereumNetwork::MAINNET
+        }
+        evm_rpc_types::RpcServices::EthSepolia(_) => {
+            cketh_common::lifecycle::EthereumNetwork::SEPOLIA
+        }
+        evm_rpc_types::RpcServices::ArbitrumOne(_) => {
+            cketh_common::lifecycle::EthereumNetwork::ARBITRUM
+        }
+        evm_rpc_types::RpcServices::BaseMainnet(_) => {
+            cketh_common::lifecycle::EthereumNetwork::BASE
+        }
+        evm_rpc_types::RpcServices::OptimismMainnet(_) => {
+            cketh_common::lifecycle::EthereumNetwork::OPTIMISM
+        }
+    }
+}
+
+pub(super) fn into_rpc_service(
+    source: evm_rpc_types::RpcService,
+) -> cketh_common::eth_rpc_client::providers::RpcService {
+    fn map_eth_mainnet_service(
+        service: evm_rpc_types::EthMainnetService,
+    ) -> cketh_common::eth_rpc_client::providers::EthMainnetService {
+        match service {
+            evm_rpc_types::EthMainnetService::Alchemy => {
+                cketh_common::eth_rpc_client::providers::EthMainnetService::Alchemy
+            }
+            evm_rpc_types::EthMainnetService::Ankr => {
+                cketh_common::eth_rpc_client::providers::EthMainnetService::Ankr
+            }
+            evm_rpc_types::EthMainnetService::BlockPi => {
+                cketh_common::eth_rpc_client::providers::EthMainnetService::BlockPi
+            }
+            evm_rpc_types::EthMainnetService::PublicNode => {
+                cketh_common::eth_rpc_client::providers::EthMainnetService::PublicNode
+            }
+            evm_rpc_types::EthMainnetService::Cloudflare => {
+                cketh_common::eth_rpc_client::providers::EthMainnetService::Cloudflare
+            }
+            evm_rpc_types::EthMainnetService::Llama => {
+                cketh_common::eth_rpc_client::providers::EthMainnetService::Llama
+            }
+        }
+    }
+
+    fn map_eth_sepolia_service(
+        service: evm_rpc_types::EthSepoliaService,
+    ) -> cketh_common::eth_rpc_client::providers::EthSepoliaService {
+        match service {
+            evm_rpc_types::EthSepoliaService::Alchemy => {
+                cketh_common::eth_rpc_client::providers::EthSepoliaService::Alchemy
+            }
+            evm_rpc_types::EthSepoliaService::Ankr => {
+                cketh_common::eth_rpc_client::providers::EthSepoliaService::Ankr
+            }
+            evm_rpc_types::EthSepoliaService::BlockPi => {
+                cketh_common::eth_rpc_client::providers::EthSepoliaService::BlockPi
+            }
+            evm_rpc_types::EthSepoliaService::PublicNode => {
+                cketh_common::eth_rpc_client::providers::EthSepoliaService::PublicNode
+            }
+            evm_rpc_types::EthSepoliaService::Sepolia => {
+                cketh_common::eth_rpc_client::providers::EthSepoliaService::Sepolia
+            }
+        }
+    }
+
+    fn map_l2_mainnet_service(
+        service: evm_rpc_types::L2MainnetService,
+    ) -> cketh_common::eth_rpc_client::providers::L2MainnetService {
+        match service {
+            evm_rpc_types::L2MainnetService::Alchemy => {
+                cketh_common::eth_rpc_client::providers::L2MainnetService::Alchemy
+            }
+            evm_rpc_types::L2MainnetService::Ankr => {
+                cketh_common::eth_rpc_client::providers::L2MainnetService::Ankr
+            }
+            evm_rpc_types::L2MainnetService::BlockPi => {
+                cketh_common::eth_rpc_client::providers::L2MainnetService::BlockPi
+            }
+            evm_rpc_types::L2MainnetService::PublicNode => {
+                cketh_common::eth_rpc_client::providers::L2MainnetService::PublicNode
+            }
+            evm_rpc_types::L2MainnetService::Llama => {
+                cketh_common::eth_rpc_client::providers::L2MainnetService::Llama
+            }
+        }
+    }
+
+    match source {
+        evm_rpc_types::RpcService::Chain(id) => {
+            cketh_common::eth_rpc_client::providers::RpcService::Chain(id)
+        }
+        evm_rpc_types::RpcService::Provider(id) => {
+            cketh_common::eth_rpc_client::providers::RpcService::Provider(id)
+        }
+        evm_rpc_types::RpcService::Custom(rpc) => {
+            cketh_common::eth_rpc_client::providers::RpcService::Custom(
+                cketh_common::eth_rpc_client::providers::RpcApi {
+                    url: rpc.url,
+                    headers: rpc.headers,
+                },
+            )
+        }
+        evm_rpc_types::RpcService::EthMainnet(service) => {
+            cketh_common::eth_rpc_client::providers::RpcService::EthMainnet(
+                map_eth_mainnet_service(service),
+            )
+        }
+        evm_rpc_types::RpcService::EthSepolia(service) => {
+            cketh_common::eth_rpc_client::providers::RpcService::EthSepolia(
+                map_eth_sepolia_service(service),
+            )
+        }
+        evm_rpc_types::RpcService::ArbitrumOne(service) => {
+            cketh_common::eth_rpc_client::providers::RpcService::ArbitrumOne(
+                map_l2_mainnet_service(service),
+            )
+        }
+        evm_rpc_types::RpcService::BaseMainnet(service) => {
+            cketh_common::eth_rpc_client::providers::RpcService::BaseMainnet(
+                map_l2_mainnet_service(service),
+            )
+        }
+        evm_rpc_types::RpcService::OptimismMainnet(service) => {
+            cketh_common::eth_rpc_client::providers::RpcService::OptimismMainnet(
+                map_l2_mainnet_service(service),
+            )
+        }
+    }
+}
+
+pub(super) fn into_rpc_api(
+    rpc: evm_rpc_types::RpcApi,
+) -> cketh_common::eth_rpc_client::providers::RpcApi {
+    cketh_common::eth_rpc_client::providers::RpcApi {
+        url: rpc.url,
+        headers: rpc.headers,
+    }
+}
+
+pub(super) fn into_rpc_services(
+    source: evm_rpc_types::RpcServices,
+    default_eth_mainnet_services: &[evm_rpc_types::EthMainnetService],
+    default_eth_sepolia_services: &[evm_rpc_types::EthSepoliaService],
+    default_l2_mainnet_services: &[evm_rpc_types::L2MainnetService],
+) -> Vec<cketh_common::eth_rpc_client::providers::RpcService> {
+    fn map_eth_mainnet_service(
+        service: evm_rpc_types::EthMainnetService,
+    ) -> cketh_common::eth_rpc_client::providers::EthMainnetService {
+        match service {
+            evm_rpc_types::EthMainnetService::Alchemy => {
+                cketh_common::eth_rpc_client::providers::EthMainnetService::Alchemy
+            }
+            evm_rpc_types::EthMainnetService::Ankr => {
+                cketh_common::eth_rpc_client::providers::EthMainnetService::Ankr
+            }
+            evm_rpc_types::EthMainnetService::BlockPi => {
+                cketh_common::eth_rpc_client::providers::EthMainnetService::BlockPi
+            }
+            evm_rpc_types::EthMainnetService::PublicNode => {
+                cketh_common::eth_rpc_client::providers::EthMainnetService::PublicNode
+            }
+            evm_rpc_types::EthMainnetService::Cloudflare => {
+                cketh_common::eth_rpc_client::providers::EthMainnetService::Cloudflare
+            }
+            evm_rpc_types::EthMainnetService::Llama => {
+                cketh_common::eth_rpc_client::providers::EthMainnetService::Llama
+            }
+        }
+    }
+
+    fn map_eth_sepolia_service(
+        service: evm_rpc_types::EthSepoliaService,
+    ) -> cketh_common::eth_rpc_client::providers::EthSepoliaService {
+        match service {
+            evm_rpc_types::EthSepoliaService::Alchemy => {
+                cketh_common::eth_rpc_client::providers::EthSepoliaService::Alchemy
+            }
+            evm_rpc_types::EthSepoliaService::Ankr => {
+                cketh_common::eth_rpc_client::providers::EthSepoliaService::Ankr
+            }
+            evm_rpc_types::EthSepoliaService::BlockPi => {
+                cketh_common::eth_rpc_client::providers::EthSepoliaService::BlockPi
+            }
+            evm_rpc_types::EthSepoliaService::PublicNode => {
+                cketh_common::eth_rpc_client::providers::EthSepoliaService::PublicNode
+            }
+            evm_rpc_types::EthSepoliaService::Sepolia => {
+                cketh_common::eth_rpc_client::providers::EthSepoliaService::Sepolia
+            }
+        }
+    }
+
+    fn map_l2_mainnet_service(
+        service: evm_rpc_types::L2MainnetService,
+    ) -> cketh_common::eth_rpc_client::providers::L2MainnetService {
+        match service {
+            evm_rpc_types::L2MainnetService::Alchemy => {
+                cketh_common::eth_rpc_client::providers::L2MainnetService::Alchemy
+            }
+            evm_rpc_types::L2MainnetService::Ankr => {
+                cketh_common::eth_rpc_client::providers::L2MainnetService::Ankr
+            }
+            evm_rpc_types::L2MainnetService::BlockPi => {
+                cketh_common::eth_rpc_client::providers::L2MainnetService::BlockPi
+            }
+            evm_rpc_types::L2MainnetService::PublicNode => {
+                cketh_common::eth_rpc_client::providers::L2MainnetService::PublicNode
+            }
+            evm_rpc_types::L2MainnetService::Llama => {
+                cketh_common::eth_rpc_client::providers::L2MainnetService::Llama
+            }
+        }
+    }
+
+    match source {
+        evm_rpc_types::RpcServices::Custom {
+            chain_id: _,
+            services,
+        } => services
+            .into_iter()
+            .map(|service| {
+                cketh_common::eth_rpc_client::providers::RpcService::Custom(into_rpc_api(service))
+            })
+            .collect(),
+        evm_rpc_types::RpcServices::EthMainnet(services) => services
+            .unwrap_or_else(|| default_eth_mainnet_services.to_vec())
+            .into_iter()
+            .map(|service| {
+                cketh_common::eth_rpc_client::providers::RpcService::EthMainnet(
+                    map_eth_mainnet_service(service),
+                )
+            })
+            .collect(),
+        evm_rpc_types::RpcServices::EthSepolia(services) => services
+            .unwrap_or_else(|| default_eth_sepolia_services.to_vec())
+            .into_iter()
+            .map(|service| {
+                cketh_common::eth_rpc_client::providers::RpcService::EthSepolia(
+                    map_eth_sepolia_service(service),
+                )
+            })
+            .collect(),
+        evm_rpc_types::RpcServices::ArbitrumOne(services) => services
+            .unwrap_or_else(|| default_l2_mainnet_services.to_vec())
+            .into_iter()
+            .map(|service| {
+                cketh_common::eth_rpc_client::providers::RpcService::ArbitrumOne(
+                    map_l2_mainnet_service(service),
+                )
+            })
+            .collect(),
+        evm_rpc_types::RpcServices::BaseMainnet(services) => services
+            .unwrap_or_else(|| default_l2_mainnet_services.to_vec())
+            .into_iter()
+            .map(|service| {
+                cketh_common::eth_rpc_client::providers::RpcService::BaseMainnet(
+                    map_l2_mainnet_service(service),
+                )
+            })
+            .collect(),
+        evm_rpc_types::RpcServices::OptimismMainnet(services) => services
+            .unwrap_or_else(|| default_l2_mainnet_services.to_vec())
+            .into_iter()
+            .map(|service| {
+                cketh_common::eth_rpc_client::providers::RpcService::OptimismMainnet(
+                    map_l2_mainnet_service(service),
+                )
+            })
+            .collect(),
+    }
+}
+
+pub(super) fn from_rpc_service(
+    service: cketh_common::eth_rpc_client::providers::RpcService,
+) -> evm_rpc_types::RpcService {
+    fn map_eth_mainnet_service(
+        service: cketh_common::eth_rpc_client::providers::EthMainnetService,
+    ) -> evm_rpc_types::EthMainnetService {
+        match service {
+            cketh_common::eth_rpc_client::providers::EthMainnetService::Alchemy => {
+                evm_rpc_types::EthMainnetService::Alchemy
+            }
+            cketh_common::eth_rpc_client::providers::EthMainnetService::Ankr => {
+                evm_rpc_types::EthMainnetService::Ankr
+            }
+            cketh_common::eth_rpc_client::providers::EthMainnetService::BlockPi => {
+                evm_rpc_types::EthMainnetService::BlockPi
+            }
+            cketh_common::eth_rpc_client::providers::EthMainnetService::PublicNode => {
+                evm_rpc_types::EthMainnetService::PublicNode
+            }
+            cketh_common::eth_rpc_client::providers::EthMainnetService::Cloudflare => {
+                evm_rpc_types::EthMainnetService::Cloudflare
+            }
+            cketh_common::eth_rpc_client::providers::EthMainnetService::Llama => {
+                evm_rpc_types::EthMainnetService::Llama
+            }
+        }
+    }
+
+    fn map_eth_sepolia_service(
+        service: cketh_common::eth_rpc_client::providers::EthSepoliaService,
+    ) -> evm_rpc_types::EthSepoliaService {
+        match service {
+            cketh_common::eth_rpc_client::providers::EthSepoliaService::Alchemy => {
+                evm_rpc_types::EthSepoliaService::Alchemy
+            }
+            cketh_common::eth_rpc_client::providers::EthSepoliaService::Ankr => {
+                evm_rpc_types::EthSepoliaService::Ankr
+            }
+            cketh_common::eth_rpc_client::providers::EthSepoliaService::BlockPi => {
+                evm_rpc_types::EthSepoliaService::BlockPi
+            }
+            cketh_common::eth_rpc_client::providers::EthSepoliaService::PublicNode => {
+                evm_rpc_types::EthSepoliaService::PublicNode
+            }
+            cketh_common::eth_rpc_client::providers::EthSepoliaService::Sepolia => {
+                evm_rpc_types::EthSepoliaService::Sepolia
+            }
+        }
+    }
+
+    fn map_l2_mainnet_service(
+        service: cketh_common::eth_rpc_client::providers::L2MainnetService,
+    ) -> evm_rpc_types::L2MainnetService {
+        match service {
+            cketh_common::eth_rpc_client::providers::L2MainnetService::Alchemy => {
+                evm_rpc_types::L2MainnetService::Alchemy
+            }
+            cketh_common::eth_rpc_client::providers::L2MainnetService::Ankr => {
+                evm_rpc_types::L2MainnetService::Ankr
+            }
+            cketh_common::eth_rpc_client::providers::L2MainnetService::BlockPi => {
+                evm_rpc_types::L2MainnetService::BlockPi
+            }
+            cketh_common::eth_rpc_client::providers::L2MainnetService::PublicNode => {
+                evm_rpc_types::L2MainnetService::PublicNode
+            }
+            cketh_common::eth_rpc_client::providers::L2MainnetService::Llama => {
+                evm_rpc_types::L2MainnetService::Llama
+            }
+        }
+    }
+
+    match service {
+        cketh_common::eth_rpc_client::providers::RpcService::Chain(id) => {
+            evm_rpc_types::RpcService::Chain(id)
+        }
+        cketh_common::eth_rpc_client::providers::RpcService::Provider(id) => {
+            evm_rpc_types::RpcService::Provider(id)
+        }
+        cketh_common::eth_rpc_client::providers::RpcService::Custom(rpc) => {
+            evm_rpc_types::RpcService::Custom(evm_rpc_types::RpcApi {
+                url: rpc.url,
+                headers: rpc.headers.map(|headers| {
+                    headers
+                        .into_iter()
+                        .map(|header| evm_rpc_types::HttpHeader {
+                            name: header.name,
+                            value: header.value,
+                        })
+                        .collect()
+                }),
+            })
+        }
+        cketh_common::eth_rpc_client::providers::RpcService::EthMainnet(service) => {
+            evm_rpc_types::RpcService::EthMainnet(map_eth_mainnet_service(service))
+        }
+        cketh_common::eth_rpc_client::providers::RpcService::EthSepolia(service) => {
+            evm_rpc_types::RpcService::EthSepolia(map_eth_sepolia_service(service))
+        }
+        cketh_common::eth_rpc_client::providers::RpcService::ArbitrumOne(service) => {
+            evm_rpc_types::RpcService::ArbitrumOne(map_l2_mainnet_service(service))
+        }
+        cketh_common::eth_rpc_client::providers::RpcService::BaseMainnet(service) => {
+            evm_rpc_types::RpcService::BaseMainnet(map_l2_mainnet_service(service))
+        }
+        cketh_common::eth_rpc_client::providers::RpcService::OptimismMainnet(service) => {
+            evm_rpc_types::RpcService::OptimismMainnet(map_l2_mainnet_service(service))
+        }
+    }
+}
+
 pub(super) fn into_hash(value: Hex32) -> Hash {
     Hash(value.into())
 }

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -186,6 +186,14 @@ pub(super) fn from_send_raw_transaction_result(
     }
 }
 
+pub(super) fn into_rpc_config(
+    value: evm_rpc_types::RpcConfig,
+) -> cketh_common::eth_rpc_client::RpcConfig {
+    cketh_common::eth_rpc_client::RpcConfig {
+        response_size_estimate: value.response_size_estimate,
+    }
+}
+
 pub(super) fn into_hash(value: Hex32) -> Hash {
     Hash(value.into())
 }

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -219,6 +219,7 @@ pub(super) fn into_ethereum_network(
     }
 }
 
+#[cfg(test)]
 pub(super) fn into_rpc_service(
     source: evm_rpc_types::RpcService,
 ) -> cketh_common::eth_rpc_client::providers::RpcService {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,4 @@
-use cketh_common::eth_rpc_client::providers::{
-    EthMainnetService, EthSepoliaService, L2MainnetService,
-};
+use evm_rpc_types::{EthMainnetService, EthSepoliaService, L2MainnetService};
 
 // HTTP outcall cost calculation
 // See https://internetcomputer.org/docs/current/developer-docs/gas-cost#special-features

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use candid::candid_method;
 use cketh_common::eth_rpc::RpcError;
 
 use cketh_common::eth_rpc_client::providers::RpcService;
-use cketh_common::eth_rpc_client::RpcConfig;
 use cketh_common::logs::INFO;
 use evm_rpc::accounting::{get_cost_with_collateral, get_http_request_cost};
 use evm_rpc::candid_rpc::CandidRpcClient;
@@ -43,7 +42,7 @@ pub fn require_api_key_principal_or_controller() -> Result<(), String> {
 #[candid_method(rename = "eth_getLogs")]
 pub async fn eth_get_logs(
     source: RpcServices,
-    config: Option<RpcConfig>,
+    config: Option<evm_rpc_types::RpcConfig>,
     args: evm_rpc_types::GetLogsArgs,
 ) -> MultiRpcResult<Vec<evm_rpc_types::LogEntry>> {
     match CandidRpcClient::new(source, config) {
@@ -56,7 +55,7 @@ pub async fn eth_get_logs(
 #[candid_method(rename = "eth_getBlockByNumber")]
 pub async fn eth_get_block_by_number(
     source: RpcServices,
-    config: Option<RpcConfig>,
+    config: Option<evm_rpc_types::RpcConfig>,
     block: evm_rpc_types::BlockTag,
 ) -> MultiRpcResult<evm_rpc_types::Block> {
     match CandidRpcClient::new(source, config) {
@@ -69,7 +68,7 @@ pub async fn eth_get_block_by_number(
 #[candid_method(rename = "eth_getTransactionReceipt")]
 pub async fn eth_get_transaction_receipt(
     source: RpcServices,
-    config: Option<RpcConfig>,
+    config: Option<evm_rpc_types::RpcConfig>,
     tx_hash: Hex32,
 ) -> MultiRpcResult<Option<evm_rpc_types::TransactionReceipt>> {
     match CandidRpcClient::new(source, config) {
@@ -82,7 +81,7 @@ pub async fn eth_get_transaction_receipt(
 #[candid_method(rename = "eth_getTransactionCount")]
 pub async fn eth_get_transaction_count(
     source: RpcServices,
-    config: Option<RpcConfig>,
+    config: Option<evm_rpc_types::RpcConfig>,
     args: evm_rpc_types::GetTransactionCountArgs,
 ) -> MultiRpcResult<evm_rpc_types::Nat256> {
     match CandidRpcClient::new(source, config) {
@@ -95,7 +94,7 @@ pub async fn eth_get_transaction_count(
 #[candid_method(rename = "eth_feeHistory")]
 pub async fn eth_fee_history(
     source: RpcServices,
-    config: Option<RpcConfig>,
+    config: Option<evm_rpc_types::RpcConfig>,
     args: evm_rpc_types::FeeHistoryArgs,
 ) -> MultiRpcResult<evm_rpc_types::FeeHistory> {
     match CandidRpcClient::new(source, config) {
@@ -108,7 +107,7 @@ pub async fn eth_fee_history(
 #[candid_method(rename = "eth_sendRawTransaction")]
 pub async fn eth_send_raw_transaction(
     source: RpcServices,
-    config: Option<RpcConfig>,
+    config: Option<evm_rpc_types::RpcConfig>,
     raw_signed_transaction_hex: evm_rpc_types::Hex,
 ) -> MultiRpcResult<evm_rpc_types::SendRawTransactionStatus> {
     match CandidRpcClient::new(source, config) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use evm_rpc::{
     memory::UNSTABLE_METRICS,
     types::{InitArgs, MetricRpcMethod, Metrics, MultiRpcResult},
 };
-use evm_rpc_types::{Hex32, RpcService};
+use evm_rpc_types::Hex32;
 
 pub fn require_api_key_principal_or_controller() -> Result<(), String> {
     let caller = ic_cdk::caller();
@@ -157,7 +157,7 @@ fn get_providers() -> Vec<Provider> {
 
 #[query(name = "getServiceProviderMap")]
 #[candid_method(query, rename = "getServiceProviderMap")]
-fn get_service_provider_map() -> Vec<(RpcService, ProviderId)> {
+fn get_service_provider_map() -> Vec<(evm_rpc_types::RpcService, ProviderId)> {
     SERVICE_PROVIDER_MAP.with(|map| map.iter().map(|(k, v)| (k.clone(), *v)).collect())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use candid::candid_method;
 use cketh_common::eth_rpc::RpcError;
 
-use cketh_common::eth_rpc_client::providers::RpcService;
 use cketh_common::logs::INFO;
 use evm_rpc::accounting::{get_cost_with_collateral, get_http_request_cost};
 use evm_rpc::candid_rpc::CandidRpcClient;
@@ -25,9 +24,9 @@ use ic_nervous_system_common::serve_metrics;
 use evm_rpc::{
     http::{json_rpc_request, transform_http_request},
     memory::UNSTABLE_METRICS,
-    types::{InitArgs, MetricRpcMethod, Metrics, MultiRpcResult, RpcServices},
+    types::{InitArgs, MetricRpcMethod, Metrics, MultiRpcResult},
 };
-use evm_rpc_types::Hex32;
+use evm_rpc_types::{Hex32, RpcService};
 
 pub fn require_api_key_principal_or_controller() -> Result<(), String> {
     let caller = ic_cdk::caller();
@@ -41,7 +40,7 @@ pub fn require_api_key_principal_or_controller() -> Result<(), String> {
 #[update(name = "eth_getLogs")]
 #[candid_method(rename = "eth_getLogs")]
 pub async fn eth_get_logs(
-    source: RpcServices,
+    source: evm_rpc_types::RpcServices,
     config: Option<evm_rpc_types::RpcConfig>,
     args: evm_rpc_types::GetLogsArgs,
 ) -> MultiRpcResult<Vec<evm_rpc_types::LogEntry>> {
@@ -54,7 +53,7 @@ pub async fn eth_get_logs(
 #[update(name = "eth_getBlockByNumber")]
 #[candid_method(rename = "eth_getBlockByNumber")]
 pub async fn eth_get_block_by_number(
-    source: RpcServices,
+    source: evm_rpc_types::RpcServices,
     config: Option<evm_rpc_types::RpcConfig>,
     block: evm_rpc_types::BlockTag,
 ) -> MultiRpcResult<evm_rpc_types::Block> {
@@ -67,7 +66,7 @@ pub async fn eth_get_block_by_number(
 #[update(name = "eth_getTransactionReceipt")]
 #[candid_method(rename = "eth_getTransactionReceipt")]
 pub async fn eth_get_transaction_receipt(
-    source: RpcServices,
+    source: evm_rpc_types::RpcServices,
     config: Option<evm_rpc_types::RpcConfig>,
     tx_hash: Hex32,
 ) -> MultiRpcResult<Option<evm_rpc_types::TransactionReceipt>> {
@@ -80,7 +79,7 @@ pub async fn eth_get_transaction_receipt(
 #[update(name = "eth_getTransactionCount")]
 #[candid_method(rename = "eth_getTransactionCount")]
 pub async fn eth_get_transaction_count(
-    source: RpcServices,
+    source: evm_rpc_types::RpcServices,
     config: Option<evm_rpc_types::RpcConfig>,
     args: evm_rpc_types::GetTransactionCountArgs,
 ) -> MultiRpcResult<evm_rpc_types::Nat256> {
@@ -93,7 +92,7 @@ pub async fn eth_get_transaction_count(
 #[update(name = "eth_feeHistory")]
 #[candid_method(rename = "eth_feeHistory")]
 pub async fn eth_fee_history(
-    source: RpcServices,
+    source: evm_rpc_types::RpcServices,
     config: Option<evm_rpc_types::RpcConfig>,
     args: evm_rpc_types::FeeHistoryArgs,
 ) -> MultiRpcResult<evm_rpc_types::FeeHistory> {
@@ -106,7 +105,7 @@ pub async fn eth_fee_history(
 #[update(name = "eth_sendRawTransaction")]
 #[candid_method(rename = "eth_sendRawTransaction")]
 pub async fn eth_send_raw_transaction(
-    source: RpcServices,
+    source: evm_rpc_types::RpcServices,
     config: Option<evm_rpc_types::RpcConfig>,
     raw_signed_transaction_hex: evm_rpc_types::Hex,
 ) -> MultiRpcResult<evm_rpc_types::SendRawTransactionStatus> {
@@ -123,7 +122,7 @@ pub async fn eth_send_raw_transaction(
 #[update]
 #[candid_method]
 async fn request(
-    service: RpcService,
+    service: evm_rpc_types::RpcService,
     json_rpc_payload: String,
     max_response_bytes: u64,
 ) -> Result<String, RpcError> {
@@ -140,7 +139,7 @@ async fn request(
 #[query(name = "requestCost")]
 #[candid_method(query, rename = "requestCost")]
 fn request_cost(
-    _service: RpcService,
+    _service: evm_rpc_types::RpcService,
     json_rpc_payload: String,
     max_response_bytes: u64,
 ) -> Result<u128, RpcError> {

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -1,11 +1,6 @@
+use cketh_common::eth_rpc::ProviderError;
+use evm_rpc_types::{EthMainnetService, EthSepoliaService, L2MainnetService, RpcApi, RpcService};
 use std::collections::HashMap;
-
-use cketh_common::{
-    eth_rpc::ProviderError,
-    eth_rpc_client::providers::{
-        EthMainnetService, EthSepoliaService, L2MainnetService, RpcApi, RpcService,
-    },
-};
 
 use crate::{
     constants::{

--- a/src/types.rs
+++ b/src/types.rs
@@ -427,10 +427,7 @@ impl<T> From<RpcResult<T>> for MultiRpcResult<T> {
 
 #[cfg(test)]
 mod test {
-    use cketh_common::{
-        eth_rpc::RpcError,
-        eth_rpc_client::providers::{EthMainnetService, RpcService},
-    };
+    use cketh_common::eth_rpc::RpcError;
 
     use crate::types::{ApiKey, MultiRpcResult};
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,9 +5,7 @@ use std::{marker::PhantomData, rc::Rc, str::FromStr, time::Duration};
 use assert_matches::assert_matches;
 use candid::{CandidType, Decode, Encode, Nat};
 use cketh_common::{
-    address::Address,
     eth_rpc::{HttpOutcallError, JsonRpcError, ProviderError, RpcError},
-    eth_rpc_client::providers::{EthMainnetService, EthSepoliaService, RpcApi, RpcService},
     numeric::Wei,
 };
 use ic_base_types::{CanisterId, PrincipalId};
@@ -27,11 +25,12 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use evm_rpc::{
     constants::{CONTENT_TYPE_HEADER_LOWERCASE, CONTENT_TYPE_VALUE},
     providers::PROVIDERS,
-    types::{
-        InitArgs, Metrics, MultiRpcResult, ProviderId, RpcAccess, RpcMethod, RpcResult, RpcServices,
-    },
+    types::{InitArgs, Metrics, MultiRpcResult, ProviderId, RpcAccess, RpcMethod, RpcResult},
 };
-use evm_rpc_types::{Hex, Hex32, Nat256};
+use evm_rpc_types::{
+    EthMainnetService, EthSepoliaService, Hex, Hex20, Hex32, Nat256, RpcApi, RpcService,
+    RpcServices,
+};
 use mock::{MockOutcall, MockOutcallBuilder};
 
 const DEFAULT_CALLER_TEST_ID: u64 = 10352385;
@@ -596,8 +595,8 @@ fn should_decode_checked_amount() {
 
 #[test]
 fn should_decode_address() {
-    let value = Address::from_str("0xdAC17F958D2ee523a2206206994597C13D831ec7").unwrap();
-    assert_eq!(Decode!(&Encode!(&value).unwrap(), Address).unwrap(), value);
+    let value = Hex20::from_str("0xdAC17F958D2ee523a2206206994597C13D831ec7").unwrap();
+    assert_eq!(Decode!(&Encode!(&value).unwrap(), Hex20).unwrap(), value);
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,10 +7,7 @@ use candid::{CandidType, Decode, Encode, Nat};
 use cketh_common::{
     address::Address,
     eth_rpc::{HttpOutcallError, JsonRpcError, ProviderError, RpcError},
-    eth_rpc_client::{
-        providers::{EthMainnetService, EthSepoliaService, RpcApi, RpcService},
-        RpcConfig,
-    },
+    eth_rpc_client::providers::{EthMainnetService, EthSepoliaService, RpcApi, RpcService},
     numeric::Wei,
 };
 use ic_base_types::{CanisterId, PrincipalId};
@@ -219,7 +216,7 @@ impl EvmRpcSetup {
     pub fn eth_get_logs(
         &self,
         source: RpcServices,
-        config: Option<RpcConfig>,
+        config: Option<evm_rpc_types::RpcConfig>,
         args: evm_rpc_types::GetLogsArgs,
     ) -> CallFlow<MultiRpcResult<Vec<evm_rpc_types::LogEntry>>> {
         self.call_update("eth_getLogs", Encode!(&source, &config, &args).unwrap())
@@ -228,7 +225,7 @@ impl EvmRpcSetup {
     pub fn eth_get_block_by_number(
         &self,
         source: RpcServices,
-        config: Option<RpcConfig>,
+        config: Option<evm_rpc_types::RpcConfig>,
         block: evm_rpc_types::BlockTag,
     ) -> CallFlow<MultiRpcResult<evm_rpc_types::Block>> {
         self.call_update(
@@ -240,7 +237,7 @@ impl EvmRpcSetup {
     pub fn eth_get_transaction_receipt(
         &self,
         source: RpcServices,
-        config: Option<RpcConfig>,
+        config: Option<evm_rpc_types::RpcConfig>,
         tx_hash: &str,
     ) -> CallFlow<MultiRpcResult<Option<evm_rpc_types::TransactionReceipt>>> {
         self.call_update(
@@ -252,7 +249,7 @@ impl EvmRpcSetup {
     pub fn eth_get_transaction_count(
         &self,
         source: RpcServices,
-        config: Option<RpcConfig>,
+        config: Option<evm_rpc_types::RpcConfig>,
         args: evm_rpc_types::GetTransactionCountArgs,
     ) -> CallFlow<MultiRpcResult<Nat256>> {
         self.call_update(
@@ -264,7 +261,7 @@ impl EvmRpcSetup {
     pub fn eth_fee_history(
         &self,
         source: RpcServices,
-        config: Option<RpcConfig>,
+        config: Option<evm_rpc_types::RpcConfig>,
         args: evm_rpc_types::FeeHistoryArgs,
     ) -> CallFlow<MultiRpcResult<Option<evm_rpc_types::FeeHistory>>> {
         self.call_update("eth_feeHistory", Encode!(&source, &config, &args).unwrap())
@@ -273,7 +270,7 @@ impl EvmRpcSetup {
     pub fn eth_send_raw_transaction(
         &self,
         source: RpcServices,
-        config: Option<RpcConfig>,
+        config: Option<evm_rpc_types::RpcConfig>,
         signed_raw_transaction_hex: &str,
     ) -> CallFlow<MultiRpcResult<evm_rpc_types::SendRawTransactionStatus>> {
         let signed_raw_transaction_hex: Hex = signed_raw_transaction_hex.parse().unwrap();
@@ -1390,7 +1387,7 @@ fn should_use_custom_response_size_estimate() {
     let response = setup
         .eth_get_logs(
             RpcServices::EthMainnet(Some(vec![EthMainnetService::Cloudflare])),
-            Some(RpcConfig {
+            Some(evm_rpc_types::RpcConfig {
                 response_size_estimate: Some(max_response_bytes),
             }),
             evm_rpc_types::GetLogsArgs {


### PR DESCRIPTION
Follow-up on #257 to move the following types to the `evm_rpc_types` crate:

1. `EthMainnetService`
2. `EthSepoliaService`
3. `HttpHeader`
4. `L2MainnetService`
5. `RpcApi`
6. `RpcConfig`
7. `RpcService`
8. `RpcServices`


so that the public API of all methods in `main.rs` only use types from that crate as arguments.