### PR TITLE
refactor: move types related to result to `evm-rpc-types`

### DIFF
--- a/evm_rpc_types/CHANGELOG.md
+++ b/evm_rpc_types/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - v1.0 Move `RpcConfig` to this crate.
 - v1.0 Move `SendRawTransactionStatus` to this crate.
 - v1.0 Move `TransactionReceipt` to this crate.
-- v1.0 Move providers-related struct `EthMainnetService`, `EthSepoliaService`, `HttpHeader`, `L2MainnetService`,
+- v1.0 Move providers-related types `EthMainnetService`, `EthSepoliaService`, `HttpHeader`, `L2MainnetService`,
   `RpcApi`, `RpcConfig`, `RpcService`, `RpcServices` to this crate.
-- v1.0 Move result-related struct  `MultiRpcResult`, `RpcResult` to this crate.
+- v1.0 Move result-related types `HttpOutcallError`, `JsonRpcError`, `MultiRpcResult`, `ProviderError`, `RpcError`,
+  `RpcResult`, `ValidationError` to this crate.

--- a/evm_rpc_types/CHANGELOG.md
+++ b/evm_rpc_types/CHANGELOG.md
@@ -22,5 +22,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - v1.0 Move `SendRawTransactionStatus` to this crate.
 - v1.0 Move `TransactionReceipt` to this crate.
 - v1.0 Move providers-related struct `EthMainnetService`, `EthSepoliaService`, `HttpHeader`, `L2MainnetService`,
-  `RpcApi`, `RpcConfig`,
-  `RpcService`, `RpcServices` to this crate.
+  `RpcApi`, `RpcConfig`, `RpcService`, `RpcServices` to this crate.
+- v1.0 Move result-related struct  `MultiRpcResult`, `RpcResult` to this crate.

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -16,7 +16,10 @@ use std::str::FromStr;
 
 pub use request::{FeeHistoryArgs, GetLogsArgs, GetTransactionCountArgs};
 pub use response::{Block, FeeHistory, LogEntry, SendRawTransactionStatus, TransactionReceipt};
-pub use result::{MultiRpcResult, RpcResult};
+pub use result::{
+    HttpOutcallError, JsonRpcError, MultiRpcResult, ProviderError, RpcError, RpcResult,
+    ValidationError,
+};
 pub use rpc_client::{
     EthMainnetService, EthSepoliaService, HttpHeader, L2MainnetService, RpcApi, RpcConfig,
     RpcService, RpcServices,

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -1,6 +1,11 @@
 #[cfg(test)]
 mod tests;
 
+mod request;
+mod response;
+mod result;
+mod rpc_client;
+
 use candid::types::{Serializer, Type};
 use candid::{CandidType, Nat};
 use hex::FromHexError;
@@ -9,12 +14,9 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Formatter;
 use std::str::FromStr;
 
-mod request;
-mod response;
-mod rpc_client;
-
 pub use request::{FeeHistoryArgs, GetLogsArgs, GetTransactionCountArgs};
 pub use response::{Block, FeeHistory, LogEntry, SendRawTransactionStatus, TransactionReceipt};
+pub use result::{MultiRpcResult, RpcResult};
 pub use rpc_client::{
     EthMainnetService, EthSepoliaService, HttpHeader, L2MainnetService, RpcApi, RpcConfig,
     RpcService, RpcServices,

--- a/evm_rpc_types/src/result/mod.rs
+++ b/evm_rpc_types/src/result/mod.rs
@@ -1,0 +1,111 @@
+#[cfg(test)]
+mod tests;
+
+use crate::RpcService;
+use candid::{CandidType, Deserialize};
+use ic_cdk::api::call::RejectionCode;
+
+pub type RpcResult<T> = Result<T, RpcError>;
+
+#[derive(Clone, Debug, Eq, PartialEq, CandidType, Deserialize)]
+pub enum MultiRpcResult<T> {
+    Consistent(RpcResult<T>),
+    Inconsistent(Vec<(RpcService, RpcResult<T>)>),
+}
+
+impl<T> MultiRpcResult<T> {
+    pub fn map<R>(self, mut f: impl FnMut(T) -> R) -> MultiRpcResult<R> {
+        match self {
+            MultiRpcResult::Consistent(result) => MultiRpcResult::Consistent(result.map(f)),
+            MultiRpcResult::Inconsistent(results) => MultiRpcResult::Inconsistent(
+                results
+                    .into_iter()
+                    .map(|(service, result)| {
+                        (
+                            service,
+                            match result {
+                                Ok(ok) => Ok(f(ok)),
+                                Err(err) => Err(err),
+                            },
+                        )
+                    })
+                    .collect(),
+            ),
+        }
+    }
+
+    pub fn consistent(self) -> Option<RpcResult<T>> {
+        match self {
+            MultiRpcResult::Consistent(result) => Some(result),
+            MultiRpcResult::Inconsistent(_) => None,
+        }
+    }
+
+    pub fn inconsistent(self) -> Option<Vec<(RpcService, RpcResult<T>)>> {
+        match self {
+            MultiRpcResult::Consistent(_) => None,
+            MultiRpcResult::Inconsistent(results) => Some(results),
+        }
+    }
+
+    pub fn expect_consistent(self) -> RpcResult<T> {
+        self.consistent().expect("expected consistent results")
+    }
+
+    pub fn expect_inconsistent(self) -> Vec<(RpcService, RpcResult<T>)> {
+        self.inconsistent().expect("expected inconsistent results")
+    }
+}
+
+impl<T> From<RpcResult<T>> for MultiRpcResult<T> {
+    fn from(result: RpcResult<T>) -> Self {
+        MultiRpcResult::Consistent(result)
+    }
+}
+
+
+#[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize)]
+pub enum RpcError {
+    ProviderError(ProviderError),
+    HttpOutcallError(HttpOutcallError),
+    JsonRpcError(JsonRpcError),
+    ValidationError(ValidationError),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize)]
+pub enum ProviderError {
+    NoPermission,
+    TooFewCycles { expected: u128, received: u128 },
+    ProviderNotFound,
+    MissingRequiredProvider,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, CandidType, Deserialize)]
+pub enum HttpOutcallError {
+    /// Error from the IC system API.
+    IcError {
+        code: RejectionCode,
+        message: String,
+    },
+    /// Response is not a valid JSON-RPC response,
+    /// which means that the response was not successful (status other than 2xx)
+    /// or that the response body could not be deserialized into a JSON-RPC response.
+    InvalidHttpJsonRpcResponse {
+        status: u16,
+        body: String,
+        #[serde(rename = "parsingError")]
+        parsing_error: Option<String>,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, CandidType, Deserialize)]
+pub struct JsonRpcError {
+    pub code: i64,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, CandidType, Deserialize)]
+pub enum ValidationError {
+    Custom(String),
+    InvalidHex(String),
+}

--- a/evm_rpc_types/src/result/mod.rs
+++ b/evm_rpc_types/src/result/mod.rs
@@ -63,7 +63,6 @@ impl<T> From<RpcResult<T>> for MultiRpcResult<T> {
     }
 }
 
-
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize)]
 pub enum RpcError {
     ProviderError(ProviderError),
@@ -108,4 +107,28 @@ pub struct JsonRpcError {
 pub enum ValidationError {
     Custom(String),
     InvalidHex(String),
+}
+
+impl From<ProviderError> for RpcError {
+    fn from(err: ProviderError) -> Self {
+        RpcError::ProviderError(err)
+    }
+}
+
+impl From<HttpOutcallError> for RpcError {
+    fn from(err: HttpOutcallError) -> Self {
+        RpcError::HttpOutcallError(err)
+    }
+}
+
+impl From<JsonRpcError> for RpcError {
+    fn from(err: JsonRpcError) -> Self {
+        RpcError::JsonRpcError(err)
+    }
+}
+
+impl From<ValidationError> for RpcError {
+    fn from(err: ValidationError) -> Self {
+        RpcError::ValidationError(err)
+    }
 }

--- a/evm_rpc_types/src/result/tests.rs
+++ b/evm_rpc_types/src/result/tests.rs
@@ -1,0 +1,60 @@
+use crate::result::{ProviderError, RpcError};
+use crate::{EthMainnetService, MultiRpcResult, RpcService};
+
+#[test]
+fn test_multi_rpc_result_map() {
+    let err = RpcError::ProviderError(ProviderError::ProviderNotFound);
+    assert_eq!(
+        MultiRpcResult::Consistent(Ok(5)).map(|n| n + 1),
+        MultiRpcResult::Consistent(Ok(6))
+    );
+    assert_eq!(
+        MultiRpcResult::Consistent(Err(err.clone())).map(|()| unreachable!()),
+        MultiRpcResult::Consistent(Err(err.clone()))
+    );
+    assert_eq!(
+        MultiRpcResult::Inconsistent(vec![(
+            RpcService::EthMainnet(EthMainnetService::Ankr),
+            Ok(5)
+        )])
+        .map(|n| n + 1),
+        MultiRpcResult::Inconsistent(vec![(
+            RpcService::EthMainnet(EthMainnetService::Ankr),
+            Ok(6)
+        )])
+    );
+    assert_eq!(
+        MultiRpcResult::Inconsistent(vec![
+            (RpcService::EthMainnet(EthMainnetService::Ankr), Ok(5)),
+            (
+                RpcService::EthMainnet(EthMainnetService::Cloudflare),
+                Ok(10)
+            )
+        ])
+        .map(|n| n + 1),
+        MultiRpcResult::Inconsistent(vec![
+            (RpcService::EthMainnet(EthMainnetService::Ankr), Ok(6)),
+            (
+                RpcService::EthMainnet(EthMainnetService::Cloudflare),
+                Ok(11)
+            )
+        ])
+    );
+    assert_eq!(
+        MultiRpcResult::Inconsistent(vec![
+            (RpcService::EthMainnet(EthMainnetService::Ankr), Ok(5)),
+            (
+                RpcService::EthMainnet(EthMainnetService::PublicNode),
+                Err(err.clone())
+            )
+        ])
+        .map(|n| n + 1),
+        MultiRpcResult::Inconsistent(vec![
+            (RpcService::EthMainnet(EthMainnetService::Ankr), Ok(6)),
+            (
+                RpcService::EthMainnet(EthMainnetService::PublicNode),
+                Err(err)
+            )
+        ])
+    );
+}

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -588,6 +588,148 @@ pub(super) fn from_rpc_service(
     }
 }
 
+pub(super) fn into_provider_error(
+    error: evm_rpc_types::ProviderError,
+) -> cketh_common::eth_rpc::ProviderError {
+    match error {
+        evm_rpc_types::ProviderError::NoPermission => {
+            cketh_common::eth_rpc::ProviderError::NoPermission
+        }
+        evm_rpc_types::ProviderError::TooFewCycles { expected, received } => {
+            cketh_common::eth_rpc::ProviderError::TooFewCycles { expected, received }
+        }
+        evm_rpc_types::ProviderError::ProviderNotFound => {
+            cketh_common::eth_rpc::ProviderError::ProviderNotFound
+        }
+        evm_rpc_types::ProviderError::MissingRequiredProvider => {
+            cketh_common::eth_rpc::ProviderError::MissingRequiredProvider
+        }
+    }
+}
+
+pub(super) fn into_rpc_error(value: evm_rpc_types::RpcError) -> cketh_common::eth_rpc::RpcError {
+    fn map_http_outcall_error(
+        error: evm_rpc_types::HttpOutcallError,
+    ) -> cketh_common::eth_rpc::HttpOutcallError {
+        match error {
+            evm_rpc_types::HttpOutcallError::IcError { code, message } => {
+                cketh_common::eth_rpc::HttpOutcallError::IcError { code, message }
+            }
+            evm_rpc_types::HttpOutcallError::InvalidHttpJsonRpcResponse {
+                status,
+                body,
+                parsing_error,
+            } => cketh_common::eth_rpc::HttpOutcallError::InvalidHttpJsonRpcResponse {
+                status,
+                body,
+                parsing_error,
+            },
+        }
+    }
+
+    fn map_json_rpc_error(
+        error: evm_rpc_types::JsonRpcError,
+    ) -> cketh_common::eth_rpc::JsonRpcError {
+        cketh_common::eth_rpc::JsonRpcError {
+            code: error.code,
+            message: error.message,
+        }
+    }
+
+    fn map_validation_error(
+        error: evm_rpc_types::ValidationError,
+    ) -> cketh_common::eth_rpc::ValidationError {
+        match error {
+            evm_rpc_types::ValidationError::Custom(message) => {
+                cketh_common::eth_rpc::ValidationError::Custom(message)
+            }
+            evm_rpc_types::ValidationError::InvalidHex(message) => {
+                cketh_common::eth_rpc::ValidationError::InvalidHex(message)
+            }
+        }
+    }
+
+    match value {
+        evm_rpc_types::RpcError::ProviderError(error) => into_provider_error(error).into(),
+        evm_rpc_types::RpcError::HttpOutcallError(error) => map_http_outcall_error(error).into(),
+        evm_rpc_types::RpcError::JsonRpcError(error) => map_json_rpc_error(error).into(),
+        evm_rpc_types::RpcError::ValidationError(error) => map_validation_error(error).into(),
+    }
+}
+
+fn from_provider_error(
+    error: cketh_common::eth_rpc::ProviderError,
+) -> evm_rpc_types::ProviderError {
+    match error {
+        cketh_common::eth_rpc::ProviderError::NoPermission => {
+            evm_rpc_types::ProviderError::NoPermission
+        }
+        cketh_common::eth_rpc::ProviderError::TooFewCycles { expected, received } => {
+            evm_rpc_types::ProviderError::TooFewCycles { expected, received }
+        }
+        cketh_common::eth_rpc::ProviderError::ProviderNotFound => {
+            evm_rpc_types::ProviderError::ProviderNotFound
+        }
+        cketh_common::eth_rpc::ProviderError::MissingRequiredProvider => {
+            evm_rpc_types::ProviderError::MissingRequiredProvider
+        }
+    }
+}
+
+pub(super) fn from_rpc_error(value: cketh_common::eth_rpc::RpcError) -> evm_rpc_types::RpcError {
+    fn map_http_outcall_error(
+        error: cketh_common::eth_rpc::HttpOutcallError,
+    ) -> evm_rpc_types::HttpOutcallError {
+        match error {
+            cketh_common::eth_rpc::HttpOutcallError::IcError { code, message } => {
+                evm_rpc_types::HttpOutcallError::IcError { code, message }
+            }
+            cketh_common::eth_rpc::HttpOutcallError::InvalidHttpJsonRpcResponse {
+                status,
+                body,
+                parsing_error,
+            } => evm_rpc_types::HttpOutcallError::InvalidHttpJsonRpcResponse {
+                status,
+                body,
+                parsing_error,
+            },
+        }
+    }
+
+    fn map_json_rpc_error(
+        error: cketh_common::eth_rpc::JsonRpcError,
+    ) -> evm_rpc_types::JsonRpcError {
+        evm_rpc_types::JsonRpcError {
+            code: error.code,
+            message: error.message,
+        }
+    }
+
+    fn map_validation_error(
+        error: cketh_common::eth_rpc::ValidationError,
+    ) -> evm_rpc_types::ValidationError {
+        match error {
+            cketh_common::eth_rpc::ValidationError::Custom(message) => {
+                evm_rpc_types::ValidationError::Custom(message)
+            }
+            cketh_common::eth_rpc::ValidationError::InvalidHex(message) => {
+                evm_rpc_types::ValidationError::InvalidHex(message)
+            }
+        }
+    }
+
+    match value {
+        cketh_common::eth_rpc::RpcError::ProviderError(error) => from_provider_error(error).into(),
+        cketh_common::eth_rpc::RpcError::HttpOutcallError(error) => {
+            map_http_outcall_error(error).into()
+        }
+        cketh_common::eth_rpc::RpcError::JsonRpcError(error) => map_json_rpc_error(error).into(),
+        cketh_common::eth_rpc::RpcError::ValidationError(error) => {
+            map_validation_error(error).into()
+        }
+    }
+}
+
 pub(super) fn into_hash(value: Hex32) -> Hash {
     Hash(value.into())
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,18 +1,17 @@
-use cketh_common::eth_rpc::{HttpOutcallError, ProviderError, RpcError, ValidationError};
-use ic_cdk::api::management_canister::http_request::{
-    CanisterHttpRequestArgument, HttpHeader, HttpMethod, HttpResponse, TransformArgs,
-    TransformContext,
-};
-use num_traits::ToPrimitive;
-
 use crate::{
     accounting::{get_cost_with_collateral, get_http_request_cost},
     add_metric_entry,
     constants::{CONTENT_TYPE_HEADER_LOWERCASE, CONTENT_TYPE_VALUE, SERVICE_HOSTS_BLOCKLIST},
     memory::is_demo_active,
-    types::{MetricRpcHost, MetricRpcMethod, ResolvedRpcService, RpcResult},
+    types::{MetricRpcHost, MetricRpcMethod, ResolvedRpcService},
     util::canonicalize_json,
 };
+use evm_rpc_types::{HttpOutcallError, ProviderError, RpcError, RpcResult, ValidationError};
+use ic_cdk::api::management_canister::http_request::{
+    CanisterHttpRequestArgument, HttpHeader, HttpMethod, HttpResponse, TransformArgs,
+    TransformContext,
+};
+use num_traits::ToPrimitive;
 
 pub async fn json_rpc_request(
     service: ResolvedRpcService,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use candid::candid_method;
-
 use cketh_common::logs::INFO;
 use evm_rpc::accounting::{get_cost_with_collateral, get_http_request_cost};
 use evm_rpc::candid_rpc::CandidRpcClient;
@@ -11,7 +10,13 @@ use evm_rpc::memory::{
 };
 use evm_rpc::metrics::encode_metrics;
 use evm_rpc::providers::{find_provider, resolve_rpc_service, PROVIDERS, SERVICE_PROVIDER_MAP};
-use evm_rpc::types::{Provider, ProviderId, RpcAccess, RpcResult};
+use evm_rpc::types::{Provider, ProviderId, RpcAccess};
+use evm_rpc::{
+    http::{json_rpc_request, transform_http_request},
+    memory::UNSTABLE_METRICS,
+    types::{InitArgs, MetricRpcMethod, Metrics},
+};
+use evm_rpc_types::{Hex32, MultiRpcResult, RpcResult};
 use ic_canister_log::log;
 use ic_canisters_http_types::{
     HttpRequest as AssetHttpRequest, HttpResponse as AssetHttpResponse, HttpResponseBuilder,
@@ -20,13 +25,6 @@ use ic_cdk::api::is_controller;
 use ic_cdk::api::management_canister::http_request::{HttpResponse, TransformArgs};
 use ic_cdk::{query, update};
 use ic_nervous_system_common::serve_metrics;
-
-use evm_rpc::{
-    http::{json_rpc_request, transform_http_request},
-    memory::UNSTABLE_METRICS,
-    types::{InitArgs, MetricRpcMethod, Metrics, MultiRpcResult},
-};
-use evm_rpc_types::Hex32;
 
 pub fn require_api_key_principal_or_controller() -> Result<(), String> {
     let caller = ic_cdk::caller();

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -1,5 +1,6 @@
-use cketh_common::eth_rpc::ProviderError;
-use evm_rpc_types::{EthMainnetService, EthSepoliaService, L2MainnetService, RpcApi, RpcService};
+use evm_rpc_types::{
+    EthMainnetService, EthSepoliaService, L2MainnetService, ProviderError, RpcApi, RpcService,
+};
 use std::collections::HashMap;
 
 use crate::{

--- a/src/types.rs
+++ b/src/types.rs
@@ -409,90 +409,10 @@ impl<T> From<RpcResult<T>> for MultiRpcResult<T> {
 #[cfg(test)]
 mod test {
     use candid::Principal;
-    use cketh_common::eth_rpc::RpcError;
     use ic_stable_structures::Storable;
 
-    use crate::types::{ApiKey, BoolStorable, MultiRpcResult, PrincipalStorable};
+    use crate::types::{ApiKey, BoolStorable, PrincipalStorable};
 
-    #[test]
-    fn test_multi_rpc_result_map() {
-        use cketh_common::eth_rpc::ProviderError;
-
-        let err = RpcError::ProviderError(ProviderError::ProviderNotFound);
-        assert_eq!(
-            MultiRpcResult::Consistent(Ok(5)).map(|n| n + 1),
-            MultiRpcResult::Consistent(Ok(6))
-        );
-        assert_eq!(
-            MultiRpcResult::Consistent(Err(err.clone())).map(|()| unreachable!()),
-            MultiRpcResult::Consistent(Err(err.clone()))
-        );
-        assert_eq!(
-            MultiRpcResult::Inconsistent(vec![(
-                evm_rpc_types::RpcService::EthMainnet(evm_rpc_types::EthMainnetService::Ankr),
-                Ok(5)
-            )])
-            .map(|n| n + 1),
-            MultiRpcResult::Inconsistent(vec![(
-                evm_rpc_types::RpcService::EthMainnet(evm_rpc_types::EthMainnetService::Ankr),
-                Ok(6)
-            )])
-        );
-        assert_eq!(
-            MultiRpcResult::Inconsistent(vec![
-                (
-                    evm_rpc_types::RpcService::EthMainnet(evm_rpc_types::EthMainnetService::Ankr),
-                    Ok(5)
-                ),
-                (
-                    evm_rpc_types::RpcService::EthMainnet(
-                        evm_rpc_types::EthMainnetService::Cloudflare
-                    ),
-                    Ok(10)
-                )
-            ])
-            .map(|n| n + 1),
-            MultiRpcResult::Inconsistent(vec![
-                (
-                    evm_rpc_types::RpcService::EthMainnet(evm_rpc_types::EthMainnetService::Ankr),
-                    Ok(6)
-                ),
-                (
-                    evm_rpc_types::RpcService::EthMainnet(
-                        evm_rpc_types::EthMainnetService::Cloudflare
-                    ),
-                    Ok(11)
-                )
-            ])
-        );
-        assert_eq!(
-            MultiRpcResult::Inconsistent(vec![
-                (
-                    evm_rpc_types::RpcService::EthMainnet(evm_rpc_types::EthMainnetService::Ankr),
-                    Ok(5)
-                ),
-                (
-                    evm_rpc_types::RpcService::EthMainnet(
-                        evm_rpc_types::EthMainnetService::PublicNode
-                    ),
-                    Err(err.clone())
-                )
-            ])
-            .map(|n| n + 1),
-            MultiRpcResult::Inconsistent(vec![
-                (
-                    evm_rpc_types::RpcService::EthMainnet(evm_rpc_types::EthMainnetService::Ankr),
-                    Ok(6)
-                ),
-                (
-                    evm_rpc_types::RpcService::EthMainnet(
-                        evm_rpc_types::EthMainnetService::PublicNode
-                    ),
-                    Err(err)
-                )
-            ])
-        );
-    }
 
     #[test]
     fn test_api_key_debug_output() {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,7 +2,6 @@ mod mock;
 
 use assert_matches::assert_matches;
 use candid::{CandidType, Decode, Encode, Nat};
-use cketh_common::numeric::Wei;
 use evm_rpc::{
     constants::{CONTENT_TYPE_HEADER_LOWERCASE, CONTENT_TYPE_VALUE},
     providers::PROVIDERS,
@@ -591,8 +590,8 @@ fn should_decode_renamed_field() {
 
 #[test]
 fn should_decode_checked_amount() {
-    let value = Wei::new(123);
-    assert_eq!(Decode!(&Encode!(&value).unwrap(), Wei).unwrap(), value);
+    let value = Nat256::from(123_u32);
+    assert_eq!(Decode!(&Encode!(&value).unwrap(), Nat256).unwrap(), value);
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,12 +1,16 @@
 mod mock;
 
-use std::{marker::PhantomData, rc::Rc, str::FromStr, time::Duration};
-
 use assert_matches::assert_matches;
 use candid::{CandidType, Decode, Encode, Nat};
-use cketh_common::{
-    eth_rpc::{HttpOutcallError, JsonRpcError, ProviderError, RpcError},
-    numeric::Wei,
+use cketh_common::numeric::Wei;
+use evm_rpc::{
+    constants::{CONTENT_TYPE_HEADER_LOWERCASE, CONTENT_TYPE_VALUE},
+    providers::PROVIDERS,
+    types::{InitArgs, Metrics, ProviderId, RpcAccess, RpcMethod},
+};
+use evm_rpc_types::{
+    EthMainnetService, EthSepoliaService, Hex, Hex20, Hex32, HttpOutcallError, JsonRpcError,
+    MultiRpcResult, Nat256, ProviderError, RpcApi, RpcError, RpcResult, RpcService, RpcServices,
 };
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_cdk::api::management_canister::http_request::{
@@ -20,18 +24,9 @@ use ic_state_machine_tests::{
 };
 use ic_test_utilities_load_wasm::load_wasm;
 use maplit::hashmap;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-
-use evm_rpc::{
-    constants::{CONTENT_TYPE_HEADER_LOWERCASE, CONTENT_TYPE_VALUE},
-    providers::PROVIDERS,
-    types::{InitArgs, Metrics, MultiRpcResult, ProviderId, RpcAccess, RpcMethod, RpcResult},
-};
-use evm_rpc_types::{
-    EthMainnetService, EthSepoliaService, Hex, Hex20, Hex32, Nat256, RpcApi, RpcService,
-    RpcServices,
-};
 use mock::{MockOutcall, MockOutcallBuilder};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::{marker::PhantomData, rc::Rc, str::FromStr, time::Duration};
 
 const DEFAULT_CALLER_TEST_ID: u64 = 10352385;
 const DEFAULT_CONTROLLER_TEST_ID: u64 = 10352386;
@@ -958,7 +953,7 @@ fn candid_rpc_should_err_when_service_unavailable() {
     assert_eq!(
         result,
         Err(RpcError::HttpOutcallError(
-            cketh_common::eth_rpc::HttpOutcallError::InvalidHttpJsonRpcResponse {
+            HttpOutcallError::InvalidHttpJsonRpcResponse {
                 status: 503,
                 body: "Service unavailable".to_string(),
                 parsing_error: None,
@@ -1293,7 +1288,7 @@ fn candid_rpc_should_recognize_rate_limit() {
     assert_eq!(
         result,
         Err(RpcError::HttpOutcallError(
-            cketh_common::eth_rpc::HttpOutcallError::InvalidHttpJsonRpcResponse {
+            HttpOutcallError::InvalidHttpJsonRpcResponse {
                 status: 429,
                 body: "(Rate limit error message)".to_string(),
                 parsing_error: None


### PR DESCRIPTION
Follow-up on #257 to move the following types to the `evm_rpc_types` crate:

1. `HttpOutcallError`
2. `JsonRpcError`
3. `MultiRpcResult`
4. `ProviderError`
5. `RpcError`,
6.   `RpcResult`
7. `ValidationError`

so that the public API of all methods in `main.rs` only use types from that crate as return types.