### PR TITLE
refactor: move types

### DIFF
--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -59,7 +59,7 @@ impl CandidRpcClient {
         &self,
         args: evm_rpc_types::GetLogsArgs,
     ) -> MultiRpcResult<Vec<evm_rpc_types::LogEntry>> {
-        use crate::candid_rpc::cketh_conversion::from_log_entries;
+        use crate::candid_rpc::cketh_conversion::{from_log_entries, into_get_logs_param};
 
         if let (
             Some(evm_rpc_types::BlockTag::Number(from)),
@@ -79,7 +79,7 @@ impl CandidRpcClient {
         }
         process_result(
             RpcMethod::EthGetLogs,
-            self.client.eth_get_logs(args.into()).await,
+            self.client.eth_get_logs(into_get_logs_param(args)).await,
         )
         .map(from_log_entries)
     }

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -150,7 +150,7 @@ impl CandidRpcClient {
         process_result(
             RpcMethod::EthSendRawTransaction,
             self.client
-                .multi_eth_send_raw_transaction(raw_signed_transaction_hex.to_string())
+                .eth_send_raw_transaction(raw_signed_transaction_hex.to_string())
                 .await,
         )
         .map(|result| from_send_raw_transaction_result(transaction_hash.clone(), result))

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -59,7 +59,7 @@ impl CandidRpcClient {
         &self,
         args: evm_rpc_types::GetLogsArgs,
     ) -> MultiRpcResult<Vec<evm_rpc_types::LogEntry>> {
-        use crate::candid_rpc::cketh_conversion::{from_log_entries, into_get_logs_param};
+        use crate::candid_rpc::cketh_conversion::from_log_entries;
 
         if let (
             Some(evm_rpc_types::BlockTag::Number(from)),
@@ -79,7 +79,7 @@ impl CandidRpcClient {
         }
         process_result(
             RpcMethod::EthGetLogs,
-            self.client.eth_get_logs(into_get_logs_param(args)).await,
+            self.client.eth_get_logs(args.into()).await,
         )
         .map(from_log_entries)
     }

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -2,8 +2,8 @@
 //! This module is meant to be temporary and should be removed once the dependency on ckETH is removed,
 //! see <https://github.com/internet-computer-protocol/evm-rpc-canister/issues/243>
 
-use crate::rpc_client::json::Hash;
 use crate::rpc_client::json::requests::BlockSpec;
+use crate::rpc_client::json::Hash;
 use evm_rpc_types::{BlockTag, Hex, Hex20, Hex256, Hex32, HexByte, Nat256};
 
 pub(super) fn into_block_spec(value: BlockTag) -> BlockSpec {

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -36,7 +36,7 @@ pub(super) fn into_get_logs_param(
             .map(|topic| {
                 topic
                     .into_iter()
-                    .map(|t| crate::rpc_client::eth_rpc::FixedSizeData(t.into()))
+                    .map(|t| crate::rpc_client::json::FixedSizeData(t.into()))
                     .collect()
             })
             .collect(),

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -2,8 +2,8 @@
 //! This module is meant to be temporary and should be removed once the dependency on ckETH is removed,
 //! see <https://github.com/internet-computer-protocol/evm-rpc-canister/issues/243>
 
-use crate::rpc_client::json::Hash;
 use crate::rpc_client::json::requests::BlockSpec;
+use crate::rpc_client::json::Hash;
 use evm_rpc_types::{BlockTag, Hex, Hex20, Hex256, Hex32, HexByte, Nat256};
 
 pub(super) fn into_block_spec(value: BlockTag) -> BlockSpec {
@@ -15,31 +15,6 @@ pub(super) fn into_block_spec(value: BlockTag) -> BlockSpec {
         BlockTag::Finalized => BlockSpec::Tag(requests::BlockTag::Finalized),
         BlockTag::Earliest => BlockSpec::Tag(requests::BlockTag::Earliest),
         BlockTag::Pending => BlockSpec::Tag(requests::BlockTag::Pending),
-    }
-}
-
-pub(super) fn into_get_logs_param(
-    value: evm_rpc_types::GetLogsArgs,
-) -> crate::rpc_client::json::requests::GetLogsParam {
-    crate::rpc_client::json::requests::GetLogsParam {
-        from_block: value.from_block.map(into_block_spec).unwrap_or_default(),
-        to_block: value.to_block.map(into_block_spec).unwrap_or_default(),
-        address: value
-            .addresses
-            .into_iter()
-            .map(|address| ic_ethereum_types::Address::new(address.into()))
-            .collect(),
-        topics: value
-            .topics
-            .unwrap_or_default()
-            .into_iter()
-            .map(|topic| {
-                topic
-                    .into_iter()
-                    .map(|t| crate::rpc_client::json::FixedSizeData(t.into()))
-                    .collect()
-            })
-            .collect(),
     }
 }
 

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -2,8 +2,8 @@
 //! This module is meant to be temporary and should be removed once the dependency on ckETH is removed,
 //! see <https://github.com/internet-computer-protocol/evm-rpc-canister/issues/243>
 
-use crate::rpc_client::json::requests::BlockSpec;
 use crate::rpc_client::json::Hash;
+use crate::rpc_client::json::requests::BlockSpec;
 use evm_rpc_types::{BlockTag, Hex, Hex20, Hex256, Hex32, HexByte, Nat256};
 
 pub(super) fn into_block_spec(value: BlockTag) -> BlockSpec {
@@ -15,6 +15,31 @@ pub(super) fn into_block_spec(value: BlockTag) -> BlockSpec {
         BlockTag::Finalized => BlockSpec::Tag(requests::BlockTag::Finalized),
         BlockTag::Earliest => BlockSpec::Tag(requests::BlockTag::Earliest),
         BlockTag::Pending => BlockSpec::Tag(requests::BlockTag::Pending),
+    }
+}
+
+pub(super) fn into_get_logs_param(
+    value: evm_rpc_types::GetLogsArgs,
+) -> crate::rpc_client::json::requests::GetLogsParam {
+    crate::rpc_client::json::requests::GetLogsParam {
+        from_block: value.from_block.map(into_block_spec).unwrap_or_default(),
+        to_block: value.to_block.map(into_block_spec).unwrap_or_default(),
+        address: value
+            .addresses
+            .into_iter()
+            .map(|address| ic_ethereum_types::Address::new(address.into()))
+            .collect(),
+        topics: value
+            .topics
+            .unwrap_or_default()
+            .into_iter()
+            .map(|topic| {
+                topic
+                    .into_iter()
+                    .map(|t| crate::rpc_client::json::FixedSizeData(t.into()))
+                    .collect()
+            })
+            .collect(),
     }
 }
 

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -2,7 +2,7 @@
 //! This module is meant to be temporary and should be removed once the dependency on ckETH is removed,
 //! see <https://github.com/internet-computer-protocol/evm-rpc-canister/issues/243>
 
-use crate::rpc_client::eth_rpc::Hash;
+use crate::rpc_client::json::Hash;
 use crate::rpc_client::json::requests::BlockSpec;
 use evm_rpc_types::{BlockTag, Hex, Hex20, Hex256, Hex32, HexByte, Nat256};
 

--- a/src/rpc_client/eth_rpc/mod.rs
+++ b/src/rpc_client/eth_rpc/mod.rs
@@ -39,16 +39,6 @@ const HTTP_MAX_SIZE: u64 = 2 * 1024 * 1024;
 
 pub const MAX_PAYLOAD_SIZE: u64 = HTTP_MAX_SIZE - HEADER_SIZE_LIMIT;
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(transparent)]
-pub struct Data(#[serde(with = "ic_ethereum_types::serde_data")] pub Vec<u8>);
-
-impl AsRef<[u8]> for Data {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-
 #[derive(Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(transparent)]
 pub struct FixedSizeData(#[serde(with = "ic_ethereum_types::serde_data")] pub [u8; 32]);

--- a/src/rpc_client/eth_rpc/mod.rs
+++ b/src/rpc_client/eth_rpc/mod.rs
@@ -39,51 +39,6 @@ const HTTP_MAX_SIZE: u64 = 2 * 1024 * 1024;
 
 pub const MAX_PAYLOAD_SIZE: u64 = HTTP_MAX_SIZE - HEADER_SIZE_LIMIT;
 
-#[derive(Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash, Ord, PartialOrd)]
-pub struct Hash(#[serde(with = "ic_ethereum_types::serde_data")] pub [u8; 32]);
-
-impl Debug for Hash {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:x}", self)
-    }
-}
-
-impl Display for Hash {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:x}", self)
-    }
-}
-
-impl LowerHex for Hash {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "0x{}", hex::encode(self.0))
-    }
-}
-
-impl UpperHex for Hash {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "0x{}", hex::encode_upper(self.0))
-    }
-}
-
-impl std::str::FromStr for Hash {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if !s.starts_with("0x") {
-            return Err("Ethereum hash doesn't start with 0x".to_string());
-        }
-        let mut bytes = [0u8; 32];
-        hex::decode_to_slice(&s[2..], &mut bytes)
-            .map_err(|e| format!("failed to decode hash from hex: {}", e))?;
-        Ok(Self(bytes))
-    }
-}
-
-impl HttpResponsePayload for Hash {}
-
-impl HttpResponsePayload for Wei {}
-
 /// An envelope for all JSON-RPC requests.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct JsonRpcRequest<T> {
@@ -268,6 +223,8 @@ pub trait HttpResponsePayload {
 impl<T: HttpResponsePayload> HttpResponsePayload for Option<T> {}
 
 impl HttpResponsePayload for TransactionCount {}
+
+impl HttpResponsePayload for Wei {}
 
 /// Calls a JSON-RPC method on an Ethereum node at the specified URL.
 pub async fn call<I, O>(

--- a/src/rpc_client/eth_rpc/mod.rs
+++ b/src/rpc_client/eth_rpc/mod.rs
@@ -13,7 +13,7 @@ use crate::rpc_client::json::responses::{
 use crate::rpc_client::numeric::{TransactionCount, Wei};
 use crate::types::MetricRpcMethod;
 use candid::candid_method;
-use evm_rpc_types::{HttpOutcallError, ProviderError, RpcApi, RpcError, RpcService};
+use evm_rpc_types::{HttpOutcallError, JsonRpcError, ProviderError, RpcApi, RpcError, RpcService};
 use ic_canister_log::log;
 use ic_cdk::api::call::RejectionCode;
 use ic_cdk::api::management_canister::http_request::{
@@ -22,9 +22,9 @@ use ic_cdk::api::management_canister::http_request::{
 };
 use ic_cdk_macros::query;
 use minicbor::{Decode, Encode};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::fmt;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
 
 #[cfg(test)]
 mod tests;

--- a/src/rpc_client/eth_rpc/mod.rs
+++ b/src/rpc_client/eth_rpc/mod.rs
@@ -39,54 +39,6 @@ const HTTP_MAX_SIZE: u64 = 2 * 1024 * 1024;
 
 pub const MAX_PAYLOAD_SIZE: u64 = HTTP_MAX_SIZE - HEADER_SIZE_LIMIT;
 
-#[derive(Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
-#[serde(transparent)]
-pub struct FixedSizeData(#[serde(with = "ic_ethereum_types::serde_data")] pub [u8; 32]);
-
-impl AsRef<[u8]> for FixedSizeData {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl std::str::FromStr for FixedSizeData {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if !s.starts_with("0x") {
-            return Err("Ethereum hex string doesn't start with 0x".to_string());
-        }
-        let mut bytes = [0u8; 32];
-        hex::decode_to_slice(&s[2..], &mut bytes)
-            .map_err(|e| format!("failed to decode hash from hex: {}", e))?;
-        Ok(Self(bytes))
-    }
-}
-
-impl Debug for FixedSizeData {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:x}", self)
-    }
-}
-
-impl Display for FixedSizeData {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:x}", self)
-    }
-}
-
-impl LowerHex for FixedSizeData {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "0x{}", hex::encode(self.0))
-    }
-}
-
-impl UpperHex for FixedSizeData {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "0x{}", hex::encode_upper(self.0))
-    }
-}
-
 #[derive(Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Hash(#[serde(with = "ic_ethereum_types::serde_data")] pub [u8; 32]);
 

--- a/src/rpc_client/eth_rpc/mod.rs
+++ b/src/rpc_client/eth_rpc/mod.rs
@@ -13,7 +13,7 @@ use crate::rpc_client::json::responses::{
 use crate::rpc_client::numeric::{TransactionCount, Wei};
 use crate::types::MetricRpcMethod;
 use candid::candid_method;
-use evm_rpc_types::{HttpOutcallError, JsonRpcError, ProviderError, RpcApi, RpcError, RpcService};
+use evm_rpc_types::{HttpOutcallError, ProviderError, RpcApi, RpcError, RpcService};
 use ic_canister_log::log;
 use ic_cdk::api::call::RejectionCode;
 use ic_cdk::api::management_canister::http_request::{
@@ -22,9 +22,9 @@ use ic_cdk::api::management_canister::http_request::{
 };
 use ic_cdk_macros::query;
 use minicbor::{Decode, Encode};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
 use std::fmt;
-use std::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
+use std::fmt::Debug;
 
 #[cfg(test)]
 mod tests;

--- a/src/rpc_client/eth_rpc_error/mod.rs
+++ b/src/rpc_client/eth_rpc_error/mod.rs
@@ -1,7 +1,8 @@
 use crate::logs::DEBUG;
-use crate::rpc_client::eth_rpc::{Hash, JsonRpcReply, JsonRpcResult};
+use crate::rpc_client::eth_rpc::{JsonRpcReply, JsonRpcResult};
 use crate::rpc_client::json::responses::SendRawTransactionResult;
 use ic_canister_log::log;
+use crate::rpc_client::json::Hash;
 
 #[cfg(test)]
 mod tests;

--- a/src/rpc_client/eth_rpc_error/mod.rs
+++ b/src/rpc_client/eth_rpc_error/mod.rs
@@ -1,6 +1,5 @@
 use crate::logs::DEBUG;
-use crate::rpc_client::eth_rpc::{JsonRpcReply, JsonRpcResult};
-use crate::rpc_client::json::responses::SendRawTransactionResult;
+use crate::rpc_client::json::responses::{JsonRpcReply, JsonRpcResult, SendRawTransactionResult};
 use ic_canister_log::log;
 use crate::rpc_client::json::Hash;
 

--- a/src/rpc_client/eth_rpc_error/mod.rs
+++ b/src/rpc_client/eth_rpc_error/mod.rs
@@ -1,7 +1,7 @@
 use crate::logs::DEBUG;
 use crate::rpc_client::json::responses::{JsonRpcReply, JsonRpcResult, SendRawTransactionResult};
-use ic_canister_log::log;
 use crate::rpc_client::json::Hash;
+use ic_canister_log::log;
 
 #[cfg(test)]
 mod tests;

--- a/src/rpc_client/json/mod.rs
+++ b/src/rpc_client/json/mod.rs
@@ -1,9 +1,10 @@
 //! Types used for JSON-RPC requests and responses with Ethereum JSON-RPC providers.
 
-use std::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
-use candid::Deserialize;
-use serde::Serialize;
 use crate::rpc_client::eth_rpc::HttpResponsePayload;
+use candid::Deserialize;
+use evm_rpc_types::Hex32;
+use serde::Serialize;
+use std::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
 
 pub mod requests;
 pub mod responses;
@@ -11,6 +12,12 @@ pub mod responses;
 #[derive(Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(transparent)]
 pub struct FixedSizeData(#[serde(with = "ic_ethereum_types::serde_data")] pub [u8; 32]);
+
+impl From<Hex32> for FixedSizeData {
+    fn from(value: Hex32) -> Self {
+        Self(value.into())
+    }
+}
 
 impl AsRef<[u8]> for FixedSizeData {
     fn as_ref(&self) -> &[u8] {
@@ -98,4 +105,3 @@ impl std::str::FromStr for Hash {
 }
 
 impl HttpResponsePayload for Hash {}
-

--- a/src/rpc_client/json/mod.rs
+++ b/src/rpc_client/json/mod.rs
@@ -1,9 +1,9 @@
 //! Types used for JSON-RPC requests and responses with Ethereum JSON-RPC providers.
 
-use std::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
+use crate::rpc_client::eth_rpc::HttpResponsePayload;
 use candid::Deserialize;
 use serde::Serialize;
-use crate::rpc_client::eth_rpc::HttpResponsePayload;
+use std::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
 
 pub mod requests;
 pub mod responses;
@@ -98,4 +98,3 @@ impl std::str::FromStr for Hash {
 }
 
 impl HttpResponsePayload for Hash {}
-

--- a/src/rpc_client/json/mod.rs
+++ b/src/rpc_client/json/mod.rs
@@ -98,3 +98,4 @@ impl std::str::FromStr for Hash {
 }
 
 impl HttpResponsePayload for Hash {}
+

--- a/src/rpc_client/json/mod.rs
+++ b/src/rpc_client/json/mod.rs
@@ -1,4 +1,56 @@
 //! Types used for JSON-RPC requests and responses with Ethereum JSON-RPC providers.
 
+use std::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
+use candid::Deserialize;
+use serde::Serialize;
+
 pub mod requests;
 pub mod responses;
+
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+pub struct FixedSizeData(#[serde(with = "ic_ethereum_types::serde_data")] pub [u8; 32]);
+
+impl AsRef<[u8]> for FixedSizeData {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl std::str::FromStr for FixedSizeData {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if !s.starts_with("0x") {
+            return Err("Ethereum hex string doesn't start with 0x".to_string());
+        }
+        let mut bytes = [0u8; 32];
+        hex::decode_to_slice(&s[2..], &mut bytes)
+            .map_err(|e| format!("failed to decode hash from hex: {}", e))?;
+        Ok(Self(bytes))
+    }
+}
+
+impl Debug for FixedSizeData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:x}", self)
+    }
+}
+
+impl Display for FixedSizeData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:x}", self)
+    }
+}
+
+impl LowerHex for FixedSizeData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "0x{}", hex::encode(self.0))
+    }
+}
+
+impl UpperHex for FixedSizeData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "0x{}", hex::encode_upper(self.0))
+    }
+}

--- a/src/rpc_client/json/mod.rs
+++ b/src/rpc_client/json/mod.rs
@@ -1,10 +1,9 @@
 //! Types used for JSON-RPC requests and responses with Ethereum JSON-RPC providers.
 
-use crate::rpc_client::eth_rpc::HttpResponsePayload;
-use candid::Deserialize;
-use evm_rpc_types::Hex32;
-use serde::Serialize;
 use std::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
+use candid::Deserialize;
+use serde::Serialize;
+use crate::rpc_client::eth_rpc::HttpResponsePayload;
 
 pub mod requests;
 pub mod responses;
@@ -12,12 +11,6 @@ pub mod responses;
 #[derive(Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(transparent)]
 pub struct FixedSizeData(#[serde(with = "ic_ethereum_types::serde_data")] pub [u8; 32]);
-
-impl From<Hex32> for FixedSizeData {
-    fn from(value: Hex32) -> Self {
-        Self(value.into())
-    }
-}
 
 impl AsRef<[u8]> for FixedSizeData {
     fn as_ref(&self) -> &[u8] {
@@ -105,3 +98,4 @@ impl std::str::FromStr for Hash {
 }
 
 impl HttpResponsePayload for Hash {}
+

--- a/src/rpc_client/json/mod.rs
+++ b/src/rpc_client/json/mod.rs
@@ -3,6 +3,7 @@
 use std::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
 use candid::Deserialize;
 use serde::Serialize;
+use crate::rpc_client::eth_rpc::HttpResponsePayload;
 
 pub mod requests;
 pub mod responses;
@@ -54,3 +55,46 @@ impl UpperHex for FixedSizeData {
         write!(f, "0x{}", hex::encode_upper(self.0))
     }
 }
+
+#[derive(Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct Hash(#[serde(with = "ic_ethereum_types::serde_data")] pub [u8; 32]);
+
+impl Debug for Hash {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:x}", self)
+    }
+}
+
+impl Display for Hash {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:x}", self)
+    }
+}
+
+impl LowerHex for Hash {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "0x{}", hex::encode(self.0))
+    }
+}
+
+impl UpperHex for Hash {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "0x{}", hex::encode_upper(self.0))
+    }
+}
+
+impl std::str::FromStr for Hash {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if !s.starts_with("0x") {
+            return Err("Ethereum hash doesn't start with 0x".to_string());
+        }
+        let mut bytes = [0u8; 32];
+        hex::decode_to_slice(&s[2..], &mut bytes)
+            .map_err(|e| format!("failed to decode hash from hex: {}", e))?;
+        Ok(Self(bytes))
+    }
+}
+
+impl HttpResponsePayload for Hash {}

--- a/src/rpc_client/json/requests.rs
+++ b/src/rpc_client/json/requests.rs
@@ -156,3 +156,12 @@ impl From<GetBlockByNumberParams> for (BlockSpec, bool) {
         (value.block, value.include_full_transactions)
     }
 }
+
+/// An envelope for all JSON-RPC requests.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct JsonRpcRequest<T> {
+    pub jsonrpc: String,
+    pub method: String,
+    pub id: u64,
+    pub params: T,
+}

--- a/src/rpc_client/json/requests.rs
+++ b/src/rpc_client/json/requests.rs
@@ -41,26 +41,6 @@ pub struct GetLogsParam {
     pub topics: Vec<Vec<FixedSizeData>>,
 }
 
-impl From<GetLogsArgs> for GetLogsParam {
-    fn from(value: GetLogsArgs) -> Self {
-        Self {
-            from_block: value.from_block.map(BlockSpec::from).unwrap_or_default(),
-            to_block: value.to_block.map(BlockSpec::from).unwrap_or_default(),
-            address: value
-                .addresses
-                .into_iter()
-                .map(|address| Address::new(address.into()))
-                .collect(),
-            topics: value
-                .topics
-                .unwrap_or_default()
-                .into_iter()
-                .map(|topic| topic.into_iter().map(FixedSizeData::from).collect())
-                .collect(),
-        }
-    }
-}
-
 /// Parameters of the [`eth_feeHistory`](https://ethereum.github.io/execution-apis/api-documentation/) call.
 #[derive(Debug, Serialize, Clone)]
 #[serde(into = "(NumBlocks, BlockSpec, Vec<u8>)")]

--- a/src/rpc_client/json/requests.rs
+++ b/src/rpc_client/json/requests.rs
@@ -41,6 +41,26 @@ pub struct GetLogsParam {
     pub topics: Vec<Vec<FixedSizeData>>,
 }
 
+impl From<GetLogsArgs> for GetLogsParam {
+    fn from(value: GetLogsArgs) -> Self {
+        Self {
+            from_block: value.from_block.map(BlockSpec::from).unwrap_or_default(),
+            to_block: value.to_block.map(BlockSpec::from).unwrap_or_default(),
+            address: value
+                .addresses
+                .into_iter()
+                .map(|address| Address::new(address.into()))
+                .collect(),
+            topics: value
+                .topics
+                .unwrap_or_default()
+                .into_iter()
+                .map(|topic| topic.into_iter().map(FixedSizeData::from).collect())
+                .collect(),
+        }
+    }
+}
+
 /// Parameters of the [`eth_feeHistory`](https://ethereum.github.io/execution-apis/api-documentation/) call.
 #[derive(Debug, Serialize, Clone)]
 #[serde(into = "(NumBlocks, BlockSpec, Vec<u8>)")]

--- a/src/rpc_client/json/requests.rs
+++ b/src/rpc_client/json/requests.rs
@@ -1,6 +1,7 @@
-use crate::rpc_client::eth_rpc::FixedSizeData;
+use crate::rpc_client::json::FixedSizeData;
 use crate::rpc_client::numeric::{BlockNumber, NumBlocks};
 use candid::Deserialize;
+use evm_rpc_types::GetLogsArgs;
 use ic_ethereum_types::Address;
 use serde::Serialize;
 use std::fmt;
@@ -75,6 +76,19 @@ pub enum BlockSpec {
     Number(BlockNumber),
     /// Query the block with the specified tag.
     Tag(BlockTag),
+}
+
+impl From<evm_rpc_types::BlockTag> for BlockSpec {
+    fn from(value: evm_rpc_types::BlockTag) -> Self {
+        match value {
+            evm_rpc_types::BlockTag::Number(n) => BlockSpec::Number(n.into()),
+            evm_rpc_types::BlockTag::Latest => BlockSpec::Tag(BlockTag::Latest),
+            evm_rpc_types::BlockTag::Safe => BlockSpec::Tag(BlockTag::Safe),
+            evm_rpc_types::BlockTag::Finalized => BlockSpec::Tag(BlockTag::Finalized),
+            evm_rpc_types::BlockTag::Earliest => BlockSpec::Tag(BlockTag::Earliest),
+            evm_rpc_types::BlockTag::Pending => BlockSpec::Tag(BlockTag::Pending),
+        }
+    }
 }
 
 impl Default for BlockSpec {

--- a/src/rpc_client/json/requests.rs
+++ b/src/rpc_client/json/requests.rs
@@ -1,7 +1,6 @@
 use crate::rpc_client::json::FixedSizeData;
 use crate::rpc_client::numeric::{BlockNumber, NumBlocks};
 use candid::Deserialize;
-use evm_rpc_types::GetLogsArgs;
 use ic_ethereum_types::Address;
 use serde::Serialize;
 use std::fmt;
@@ -76,19 +75,6 @@ pub enum BlockSpec {
     Number(BlockNumber),
     /// Query the block with the specified tag.
     Tag(BlockTag),
-}
-
-impl From<evm_rpc_types::BlockTag> for BlockSpec {
-    fn from(value: evm_rpc_types::BlockTag) -> Self {
-        match value {
-            evm_rpc_types::BlockTag::Number(n) => BlockSpec::Number(n.into()),
-            evm_rpc_types::BlockTag::Latest => BlockSpec::Tag(BlockTag::Latest),
-            evm_rpc_types::BlockTag::Safe => BlockSpec::Tag(BlockTag::Safe),
-            evm_rpc_types::BlockTag::Finalized => BlockSpec::Tag(BlockTag::Finalized),
-            evm_rpc_types::BlockTag::Earliest => BlockSpec::Tag(BlockTag::Earliest),
-            evm_rpc_types::BlockTag::Pending => BlockSpec::Tag(BlockTag::Pending),
-        }
-    }
 }
 
 impl Default for BlockSpec {

--- a/src/rpc_client/json/responses.rs
+++ b/src/rpc_client/json/responses.rs
@@ -1,16 +1,14 @@
 use crate::rpc_client::amount::Amount;
-use crate::rpc_client::eth_rpc::{
-    HttpResponsePayload, ResponseTransform,
-};
+use crate::rpc_client::eth_rpc::{HttpResponsePayload, ResponseTransform};
+use crate::rpc_client::json::{FixedSizeData, Hash};
 use crate::rpc_client::numeric::{
     BlockNonce, BlockNumber, Difficulty, GasAmount, LogIndex, NumBytes, Timestamp, Wei, WeiPerGas,
 };
 use candid::Deserialize;
+use evm_rpc_types::{JsonRpcError, RpcError};
 use ic_ethereum_types::Address;
 use serde::Serialize;
 use std::fmt::{Display, Formatter};
-use evm_rpc_types::{JsonRpcError, RpcError};
-use crate::rpc_client::json::{FixedSizeData, Hash};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct TransactionReceipt {

--- a/src/rpc_client/json/responses.rs
+++ b/src/rpc_client/json/responses.rs
@@ -1,6 +1,6 @@
 use crate::rpc_client::amount::Amount;
 use crate::rpc_client::eth_rpc::{
-    Data, FixedSizeData, Hash, HttpResponsePayload, ResponseTransform,
+    FixedSizeData, Hash, HttpResponsePayload, ResponseTransform,
 };
 use crate::rpc_client::numeric::{
     BlockNonce, BlockNumber, Difficulty, GasAmount, LogIndex, NumBytes, Timestamp, Wei, WeiPerGas,
@@ -242,5 +242,15 @@ pub enum SendRawTransactionResult {
 impl HttpResponsePayload for SendRawTransactionResult {
     fn response_transform() -> Option<ResponseTransform> {
         Some(ResponseTransform::SendRawTransaction)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct Data(#[serde(with = "ic_ethereum_types::serde_data")] pub Vec<u8>);
+
+impl AsRef<[u8]> for Data {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
     }
 }

--- a/src/rpc_client/json/responses.rs
+++ b/src/rpc_client/json/responses.rs
@@ -1,6 +1,6 @@
 use crate::rpc_client::amount::Amount;
 use crate::rpc_client::eth_rpc::{
-    FixedSizeData, Hash, HttpResponsePayload, ResponseTransform,
+    Hash, HttpResponsePayload, ResponseTransform,
 };
 use crate::rpc_client::numeric::{
     BlockNonce, BlockNumber, Difficulty, GasAmount, LogIndex, NumBytes, Timestamp, Wei, WeiPerGas,
@@ -9,6 +9,7 @@ use candid::Deserialize;
 use ic_ethereum_types::Address;
 use serde::Serialize;
 use std::fmt::{Display, Formatter};
+use crate::rpc_client::json::FixedSizeData;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct TransactionReceipt {

--- a/src/rpc_client/json/responses.rs
+++ b/src/rpc_client/json/responses.rs
@@ -1,6 +1,6 @@
 use crate::rpc_client::amount::Amount;
 use crate::rpc_client::eth_rpc::{
-    Hash, HttpResponsePayload, ResponseTransform,
+    HttpResponsePayload, ResponseTransform,
 };
 use crate::rpc_client::numeric::{
     BlockNonce, BlockNumber, Difficulty, GasAmount, LogIndex, NumBytes, Timestamp, Wei, WeiPerGas,
@@ -9,7 +9,7 @@ use candid::Deserialize;
 use ic_ethereum_types::Address;
 use serde::Serialize;
 use std::fmt::{Display, Formatter};
-use crate::rpc_client::json::FixedSizeData;
+use crate::rpc_client::json::{FixedSizeData, Hash};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct TransactionReceipt {

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -4,8 +4,8 @@ use crate::rpc_client::eth_rpc::{
 };
 use crate::rpc_client::numeric::TransactionCount;
 use evm_rpc_types::{
-    EthMainnetService, EthSepoliaService, HttpOutcallError, JsonRpcError, L2MainnetService,
-    ProviderError, RpcConfig, RpcError, RpcService, RpcServices,
+    EthMainnetService, EthSepoliaService, HttpOutcallError, L2MainnetService, ProviderError,
+    RpcConfig, RpcError, RpcService, RpcServices,
 };
 use ic_canister_log::log;
 use json::requests::{
@@ -138,53 +138,6 @@ impl EthRpcClient {
         ResponseSizeEstimate::new(self.config.response_size_estimate.unwrap_or(estimate))
     }
 
-    /// Query all providers in sequence until one returns an ok result
-    /// (which could still be a JsonRpcResult::Error).
-    /// If none of the providers return an ok result, return the last error.
-    /// This method is useful in case a provider is temporarily down but should only be for
-    /// querying data that is **not** critical since the returned value comes from a single provider.
-    async fn sequential_call_until_ok<I, O>(
-        &self,
-        method: impl Into<String> + Clone,
-        params: I,
-        response_size_estimate: ResponseSizeEstimate,
-    ) -> Result<O, RpcError>
-    where
-        I: Serialize + Clone,
-        O: DeserializeOwned + HttpResponsePayload + Debug,
-    {
-        let mut last_result: Option<Result<O, RpcError>> = None;
-        for provider in self.providers() {
-            log!(
-                DEBUG,
-                "[sequential_call_until_ok]: calling provider: {:?}",
-                provider
-            );
-            let result = eth_rpc::call::<_, _>(
-                provider,
-                method.clone(),
-                params.clone(),
-                response_size_estimate,
-            )
-            .await;
-            match result {
-                Ok(value) => return Ok(value),
-                Err(RpcError::JsonRpcError(json_rpc_error @ JsonRpcError { .. })) => {
-                    log!(
-                        INFO,
-                        "{provider:?} returned JSON-RPC error {json_rpc_error:?}",
-                    );
-                    last_result = Some(Err(json_rpc_error.into()));
-                }
-                Err(e) => {
-                    log!(INFO, "Querying {provider:?} returned error {e:?}");
-                    last_result = Some(Err(e));
-                }
-            };
-        }
-        last_result.unwrap_or_else(|| panic!("BUG: No providers in RPC client {:?}", self))
-    }
-
     /// Query all providers in parallel and return all results.
     /// It's up to the caller to decide how to handle the results, which could be inconsistent
     /// (e.g., if different providers gave different responses).
@@ -289,21 +242,9 @@ impl EthRpcClient {
     pub async fn eth_send_raw_transaction(
         &self,
         raw_signed_transaction_hex: String,
-    ) -> Result<SendRawTransactionResult, RpcError> {
+    ) -> Result<SendRawTransactionResult, MultiCallError<SendRawTransactionResult>> {
         // A successful reply is under 256 bytes, but we expect most calls to end with an error
         // since we submit the same transaction from multiple nodes.
-        self.sequential_call_until_ok(
-            "eth_sendRawTransaction",
-            vec![raw_signed_transaction_hex],
-            self.response_size_estimate(256 + HEADER_SIZE_LIMIT),
-        )
-        .await
-    }
-
-    pub async fn multi_eth_send_raw_transaction(
-        &self,
-        raw_signed_transaction_hex: String,
-    ) -> Result<SendRawTransactionResult, MultiCallError<SendRawTransactionResult>> {
         self.parallel_call(
             "eth_sendRawTransaction",
             vec![raw_signed_transaction_hex],

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -1,6 +1,6 @@
 use crate::logs::{DEBUG, INFO};
 use crate::rpc_client::eth_rpc::{
-    are_errors_consistent, Hash, HttpResponsePayload, ResponseSizeEstimate, HEADER_SIZE_LIMIT,
+    are_errors_consistent, HttpResponsePayload, ResponseSizeEstimate, HEADER_SIZE_LIMIT,
 };
 use crate::rpc_client::numeric::TransactionCount;
 use evm_rpc_types::{
@@ -15,6 +15,7 @@ use json::responses::{Block, FeeHistory, LogEntry, SendRawTransactionResult, Tra
 use serde::{de::DeserializeOwned, Serialize};
 use std::collections::BTreeMap;
 use std::fmt::Debug;
+use json::Hash;
 
 pub mod amount;
 pub(crate) mod eth_rpc;

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -15,7 +15,7 @@ use json::responses::{Block, FeeHistory, LogEntry, SendRawTransactionResult, Tra
 use serde::{de::DeserializeOwned, Serialize};
 use std::collections::BTreeMap;
 use std::fmt::Debug;
-use json::Hash;
+use json::{responses, Hash};
 
 pub mod amount;
 pub(crate) mod eth_rpc;
@@ -291,7 +291,7 @@ impl<T> MultiCallResults<T> {
         I: IntoIterator<
             Item = (
                 RpcService,
-                Result<crate::rpc_client::eth_rpc::JsonRpcResult<T>, RpcError>,
+                Result<responses::JsonRpcResult<T>, RpcError>,
             ),
         >,
     >(
@@ -302,8 +302,8 @@ impl<T> MultiCallResults<T> {
                 provider,
                 match result {
                     Ok(json_rpc_result) => match json_rpc_result {
-                        crate::rpc_client::eth_rpc::JsonRpcResult::Result(value) => Ok(value),
-                        crate::rpc_client::eth_rpc::JsonRpcResult::Error { code, message } => {
+                        responses::JsonRpcResult::Result(value) => Ok(value),
+                        responses::JsonRpcResult::Error { code, message } => {
                             Err(RpcError::JsonRpcError(JsonRpcError { code, message }))
                         }
                     },

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -4,18 +4,18 @@ use crate::rpc_client::eth_rpc::{
 };
 use crate::rpc_client::numeric::TransactionCount;
 use evm_rpc_types::{
-    EthMainnetService, EthSepoliaService, L2MainnetService, ProviderError, RpcConfig, RpcError,
-    RpcService, RpcServices,
+    EthMainnetService, EthSepoliaService, HttpOutcallError, L2MainnetService, ProviderError,
+    RpcConfig, RpcError, RpcService, RpcServices,
 };
 use ic_canister_log::log;
 use json::requests::{
     BlockSpec, FeeHistoryParams, GetBlockByNumberParams, GetLogsParam, GetTransactionCountParams,
 };
 use json::responses::{Block, FeeHistory, LogEntry, SendRawTransactionResult, TransactionReceipt};
-use json::Hash;
 use serde::{de::DeserializeOwned, Serialize};
 use std::collections::BTreeMap;
 use std::fmt::Debug;
+use json::{responses, Hash};
 
 pub mod amount;
 pub(crate) mod eth_rpc;
@@ -291,7 +291,7 @@ impl<T> MultiCallResults<T> {
         I: IntoIterator<
             Item = (
                 RpcService,
-                Result<json::responses::JsonRpcResult<T>, RpcError>,
+                Result<responses::JsonRpcResult<T>, RpcError>,
             ),
         >,
     >(
@@ -302,12 +302,9 @@ impl<T> MultiCallResults<T> {
                 provider,
                 match result {
                     Ok(json_rpc_result) => match json_rpc_result {
-                        json::responses::JsonRpcResult::Result(value) => Ok(value),
-                        json::responses::JsonRpcResult::Error { code, message } => {
-                            Err(RpcError::JsonRpcError(evm_rpc_types::JsonRpcError {
-                                code,
-                                message,
-                            }))
+                        responses::JsonRpcResult::Result(value) => Ok(value),
+                        responses::JsonRpcResult::Error { code, message } => {
+                            Err(RpcError::JsonRpcError(JsonRpcError { code, message }))
                         }
                     },
                     Err(e) => Err(e),
@@ -363,6 +360,12 @@ impl<T: PartialEq> MultiCallResults<T> {
             }
         }
     }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SingleCallError {
+    HttpOutcallError(HttpOutcallError),
+    JsonRpcError { code: i64, message: String },
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/src/rpc_client/tests.rs
+++ b/src/rpc_client/tests.rs
@@ -65,7 +65,7 @@ mod multi_call_results {
     const CLOUDFLARE: RpcService = RpcService::EthMainnet(EthMainnetService::Cloudflare);
 
     mod reduce_with_equality {
-        use crate::rpc_client::eth_rpc::JsonRpcResult;
+        use crate::rpc_client::json::responses::JsonRpcResult;
         use crate::rpc_client::tests::multi_call_results::{ANKR, PUBLIC_NODE};
         use crate::rpc_client::{MultiCallError, MultiCallResults};
         use evm_rpc_types::{HttpOutcallError, JsonRpcError, RpcError};
@@ -215,7 +215,7 @@ mod multi_call_results {
     }
 
     mod reduce_with_stable_majority_by_key {
-        use crate::rpc_client::eth_rpc::JsonRpcResult;
+        use crate::rpc_client::json::responses::JsonRpcResult;
         use crate::rpc_client::json::responses::FeeHistory;
         use crate::rpc_client::numeric::{BlockNumber, WeiPerGas};
         use crate::rpc_client::tests::multi_call_results::{ANKR, CLOUDFLARE, PUBLIC_NODE};

--- a/src/rpc_client/tests.rs
+++ b/src/rpc_client/tests.rs
@@ -420,7 +420,7 @@ mod multi_call_results {
 }
 
 mod eth_get_transaction_receipt {
-    use crate::rpc_client::eth_rpc::Hash;
+    use crate::rpc_client::json::Hash;
     use crate::rpc_client::json::responses::{TransactionReceipt, TransactionStatus};
     use crate::rpc_client::numeric::{BlockNumber, GasAmount, WeiPerGas};
     use assert_matches::assert_matches;

--- a/src/rpc_client/tests.rs
+++ b/src/rpc_client/tests.rs
@@ -215,8 +215,8 @@ mod multi_call_results {
     }
 
     mod reduce_with_stable_majority_by_key {
-        use crate::rpc_client::json::responses::JsonRpcResult;
         use crate::rpc_client::json::responses::FeeHistory;
+        use crate::rpc_client::json::responses::JsonRpcResult;
         use crate::rpc_client::numeric::{BlockNumber, WeiPerGas};
         use crate::rpc_client::tests::multi_call_results::{ANKR, CLOUDFLARE, PUBLIC_NODE};
         use crate::rpc_client::{MultiCallError, MultiCallResults};
@@ -420,8 +420,8 @@ mod multi_call_results {
 }
 
 mod eth_get_transaction_receipt {
-    use crate::rpc_client::json::Hash;
     use crate::rpc_client::json::responses::{TransactionReceipt, TransactionStatus};
+    use crate::rpc_client::json::Hash;
     use crate::rpc_client::numeric::{BlockNumber, GasAmount, WeiPerGas};
     use assert_matches::assert_matches;
     use proptest::proptest;


### PR DESCRIPTION
Follow-up on #279 to move JSON types into `src/rpc_client/json` and remove some unused code.