### PR TITLE
feat: Choose a consensus strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,6 +1575,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "proptest",
  "serde",
+ "strum 0.26.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ proptest = "1.5.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_bytes = "0.11.15"
+strum = { version = "0.26", features = ["derive"] }
 
 [workspace]
 members = ["e2e/rust", "evm_rpc_types"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ ic-config = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_2
 ic-crypto-test-utils-reproducible-rng = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
 ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
 ic-test-utilities-load-wasm = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
+maplit = "1"
 proptest = { workspace = true }
 serde_bytes = { workspace = true }
 rand = "0.8"

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -178,7 +178,11 @@ type SendRawTransactionResult = variant {
 };
 type RequestResult = variant { Ok : text; Err : RpcError };
 type RequestCostResult = variant { Ok : nat; Err : RpcError };
-type RpcConfig = record { responseSizeEstimate : opt nat64 };
+type RpcConfig = record { responseSizeEstimate : opt nat64; responseConsensus : opt ConsensusStrategy };
+type ConsensusStrategy = variant {
+  Equality;
+  Threshold : record { num_providers : opt nat; min_num_ok : nat };
+};
 type RpcError = variant {
   JsonRpcError : JsonRpcError;
   ProviderError : ProviderError;

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -133,6 +133,7 @@ type ProviderError = variant {
   MissingRequiredProvider;
   ProviderNotFound;
   NoPermission;
+  InvalidRpcConfig : text ;
 };
 type ProviderId = nat64;
 type ChainId = nat64;

--- a/evm_rpc_types/Cargo.toml
+++ b/evm_rpc_types/Cargo.toml
@@ -12,6 +12,7 @@ hex = { workspace = true }
 ic-cdk = { workspace = true }
 num-bigint = { workspace = true }
 serde = { workspace = true }
+strum = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -21,8 +21,8 @@ pub use result::{
     ValidationError,
 };
 pub use rpc_client::{
-    EthMainnetService, EthSepoliaService, HttpHeader, L2MainnetService, RpcApi, RpcConfig,
-    RpcService, RpcServices,
+    ConsensusStrategy, EthMainnetService, EthSepoliaService, HttpHeader, L2MainnetService, RpcApi,
+    RpcConfig, RpcService, RpcServices,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize, Default)]

--- a/evm_rpc_types/src/result/mod.rs
+++ b/evm_rpc_types/src/result/mod.rs
@@ -77,7 +77,7 @@ pub enum ProviderError {
     TooFewCycles { expected: u128, received: u128 },
     ProviderNotFound,
     MissingRequiredProvider,
-    InvalidRpcConfig(String)
+    InvalidRpcConfig(String),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, CandidType, Deserialize)]

--- a/evm_rpc_types/src/result/mod.rs
+++ b/evm_rpc_types/src/result/mod.rs
@@ -77,6 +77,7 @@ pub enum ProviderError {
     TooFewCycles { expected: u128, received: u128 },
     ProviderNotFound,
     MissingRequiredProvider,
+    InvalidRpcConfig(String)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, CandidType, Deserialize)]

--- a/evm_rpc_types/src/rpc_client/mod.rs
+++ b/evm_rpc_types/src/rpc_client/mod.rs
@@ -7,6 +7,23 @@ use serde::Serialize;
 pub struct RpcConfig {
     #[serde(rename = "responseSizeEstimate")]
     pub response_size_estimate: Option<u64>,
+
+    #[serde(rename = "responseConsensus")]
+    pub response_consensus: Option<ConsensusStrategy>
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Default, CandidType, Deserialize)]
+pub enum ConsensusStrategy {
+    /// All providers must return the same non-error result.
+    #[default]
+    Equality,
+    Threshold {
+        /// Number of providers to be queried.
+        /// Can be omitted, if caller specifies manually the providers to be used.
+        num_providers: Option<u8>,
+        /// Minimum number of providers that must return the same (non-error) result.
+        min_num_ok: u8,
+    }
 }
 
 #[derive(Clone, CandidType, Deserialize)]

--- a/evm_rpc_types/src/rpc_client/mod.rs
+++ b/evm_rpc_types/src/rpc_client/mod.rs
@@ -21,7 +21,7 @@ pub enum ConsensusStrategy {
     Equality,
     Threshold {
         /// Number of providers to be queried.
-        /// Can be omitted, if caller specifies manually the providers to be used.
+        /// Can be omitted if the caller specifies the providers to be used manually.
         num_providers: Option<u8>,
         /// Minimum number of providers that must return the same (non-error) result.
         min_num_ok: u8,

--- a/evm_rpc_types/src/rpc_client/mod.rs
+++ b/evm_rpc_types/src/rpc_client/mod.rs
@@ -2,6 +2,7 @@ pub use ic_cdk::api::management_canister::http_request::HttpHeader;
 
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
+use strum::VariantArray;
 
 #[derive(Clone, Debug, PartialEq, Eq, Default, CandidType, Deserialize)]
 pub struct RpcConfig {
@@ -9,7 +10,7 @@ pub struct RpcConfig {
     pub response_size_estimate: Option<u64>,
 
     #[serde(rename = "responseConsensus")]
-    pub response_consensus: Option<ConsensusStrategy>
+    pub response_consensus: Option<ConsensusStrategy>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Default, CandidType, Deserialize)]
@@ -23,7 +24,7 @@ pub enum ConsensusStrategy {
         num_providers: Option<u8>,
         /// Minimum number of providers that must return the same (non-error) result.
         min_num_ok: u8,
-    }
+    },
 }
 
 #[derive(Clone, CandidType, Deserialize)]
@@ -47,7 +48,18 @@ pub struct RpcApi {
 }
 
 #[derive(
-    Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize, CandidType,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    CandidType,
+    VariantArray,
 )]
 pub enum EthMainnetService {
     Alchemy,
@@ -58,8 +70,25 @@ pub enum EthMainnetService {
     Llama,
 }
 
+impl EthMainnetService {
+    pub const fn all() -> &'static [Self] {
+        EthMainnetService::VARIANTS
+    }
+}
+
 #[derive(
-    Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize, CandidType,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    CandidType,
+    VariantArray,
 )]
 pub enum EthSepoliaService {
     Alchemy,
@@ -69,8 +98,25 @@ pub enum EthSepoliaService {
     Sepolia,
 }
 
+impl EthSepoliaService {
+    pub const fn all() -> &'static [Self] {
+        EthSepoliaService::VARIANTS
+    }
+}
+
 #[derive(
-    Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize, CandidType,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    CandidType,
+    VariantArray,
 )]
 pub enum L2MainnetService {
     Alchemy,
@@ -78,6 +124,12 @@ pub enum L2MainnetService {
     BlockPi,
     PublicNode,
     Llama,
+}
+
+impl L2MainnetService {
+    pub const fn all() -> &'static [Self] {
+        L2MainnetService::VARIANTS
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize, CandidType)]

--- a/evm_rpc_types/src/rpc_client/mod.rs
+++ b/evm_rpc_types/src/rpc_client/mod.rs
@@ -1,4 +1,5 @@
 pub use ic_cdk::api::management_canister::http_request::HttpHeader;
+use std::fmt::Debug;
 
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
@@ -27,7 +28,7 @@ pub enum ConsensusStrategy {
     },
 }
 
-#[derive(Clone, CandidType, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize)]
 pub enum RpcServices {
     Custom {
         #[serde(rename = "chainId")]
@@ -45,6 +46,12 @@ pub enum RpcServices {
 pub struct RpcApi {
     pub url: String,
     pub headers: Option<Vec<HttpHeader>>,
+}
+
+impl Debug for RpcApi {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RpcApi {{ url: ***, headers: *** }}",) //URL or header value could contain API keys
+    }
 }
 
 #[derive(

--- a/evm_rpc_types/src/rpc_client/mod.rs
+++ b/evm_rpc_types/src/rpc_client/mod.rs
@@ -20,9 +20,12 @@ pub enum ConsensusStrategy {
     #[default]
     Equality,
     Threshold {
-        /// Number of providers to be queried.
-        /// Can be omitted if the caller specifies the providers to be used manually.
+        /// Number of providers to be queried:
+        /// * If `None`, will be set to the number of providers manually specified in `RpcServices`.
+        /// * If `Some`, must correspond to the number of manually specified providers in `RpcServices`;
+        ///   or if they are none indicating that default providers should be used, select the corresponding number of providers.
         num_providers: Option<u8>,
+
         /// Minimum number of providers that must return the same (non-error) result.
         min_num_ok: u8,
     },

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -1,0 +1,54 @@
+use evm_rpc_types::{EthMainnetService, EthSepoliaService, L2MainnetService, RpcApi, RpcServices};
+use ic_cdk::api::management_canister::http_request::HttpHeader;
+use proptest::arbitrary::any;
+use proptest::collection::{vec, SizeRange};
+use proptest::prelude::{Just, Strategy};
+use proptest::{option, prop_oneof};
+
+pub fn arb_rpc_services() -> impl Strategy<Value = RpcServices> {
+    prop_oneof![
+        arb_custom_rpc_services(0..=9),
+        option::of(arb_eth_mainnet_services()).prop_map(RpcServices::EthMainnet),
+        option::of(arb_eth_sepolia_services()).prop_map(RpcServices::EthSepolia),
+        option::of(arb_l2_mainnet_services()).prop_map(RpcServices::ArbitrumOne),
+        option::of(arb_l2_mainnet_services()).prop_map(RpcServices::BaseMainnet),
+        option::of(arb_l2_mainnet_services()).prop_map(RpcServices::OptimismMainnet),
+    ]
+}
+
+pub fn arb_custom_rpc_services(
+    num_providers: impl Into<SizeRange>,
+) -> impl Strategy<Value = RpcServices> {
+    (any::<u64>(), vec(arb_rpc_api(), num_providers))
+        .prop_map(|(chain_id, services)| RpcServices::Custom { chain_id, services })
+}
+
+fn arb_rpc_api() -> impl Strategy<Value = RpcApi> {
+    (".+", option::of(vec(arb_http_header(), 0..=10)))
+        .prop_map(|(url, headers)| RpcApi { url, headers })
+}
+
+fn arb_http_header() -> impl Strategy<Value = HttpHeader> {
+    (".+", ".+").prop_map(|(name, value)| HttpHeader { name, value })
+}
+
+fn arb_eth_mainnet_services() -> impl Strategy<Value = Vec<EthMainnetService>> {
+    let services = EthMainnetService::all().to_owned();
+    let max_num_services = services.len();
+    (0..=max_num_services, Just(services).prop_shuffle())
+        .prop_map(|(num_services, services)| services.into_iter().take(num_services).collect())
+}
+
+fn arb_eth_sepolia_services() -> impl Strategy<Value = Vec<EthSepoliaService>> {
+    let services = EthSepoliaService::all().to_owned();
+    let max_num_services = services.len();
+    (0..=max_num_services, Just(services).prop_shuffle())
+        .prop_map(|(num_services, services)| services.into_iter().take(num_services).collect())
+}
+
+fn arb_l2_mainnet_services() -> impl Strategy<Value = Vec<L2MainnetService>> {
+    let services = L2MainnetService::all().to_owned();
+    let max_num_services = services.len();
+    (0..=max_num_services, Just(services).prop_shuffle())
+        .prop_map(|(num_services, services)| services.into_iter().take(num_services).collect())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,6 @@ pub mod rpc_client;
 pub mod types;
 pub mod util;
 pub mod validate;
+
+#[cfg(test)]
+mod arbitrary;

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -157,7 +157,10 @@ impl Providers {
             return Err(ProviderError::ProviderNotFound);
         }
 
-        Ok(Self { chain, services: providers })
+        Ok(Self {
+            chain,
+            services: providers,
+        })
     }
 }
 
@@ -180,7 +183,12 @@ where
             min_num_ok,
         } => {
             // Ensure that
-            // min_num_ok <= num_providers <= all_providers.len()
+            // 0 < min_num_ok <= num_providers <= all_providers.len()
+            if min_num_ok == 0 {
+                return Err(ProviderError::InvalidRpcConfig(
+                    "min_num_ok must be greater than 0".to_string(),
+                ));
+            }
             match user_input {
                 None => {
                     let all_providers_len = default_providers.len() + non_default_providers.len();

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -51,7 +51,7 @@ impl EthereumNetwork {
 pub struct Providers {
     chain: EthereumNetwork,
     /// *Non-empty* set of providers to query.
-    providers: BTreeSet<RpcService>,
+    services: BTreeSet<RpcService>,
 }
 
 impl Providers {
@@ -157,7 +157,7 @@ impl Providers {
             return Err(ProviderError::ProviderNotFound);
         }
 
-        Ok(Self { chain, providers })
+        Ok(Self { chain, services: providers })
     }
 }
 
@@ -263,7 +263,7 @@ impl EthRpcClient {
     }
 
     fn providers(&self) -> &BTreeSet<RpcService> {
-        &self.providers.providers
+        &self.providers.services
     }
 
     fn response_size_estimate(&self, estimate: u64) -> ResponseSizeEstimate {

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -63,7 +63,6 @@ impl Providers {
     const NON_DEFAULT_ETH_MAINNET_SERVICES: &'static [EthMainnetService] = &[
         EthMainnetService::Alchemy,
         EthMainnetService::BlockPi,
-        EthMainnetService::Cloudflare,
         EthMainnetService::Llama,
     ];
 
@@ -72,11 +71,8 @@ impl Providers {
         EthSepoliaService::BlockPi,
         EthSepoliaService::PublicNode,
     ];
-    const NON_DEFAULT_ETH_SEPOLIA_SERVICES: &'static [EthSepoliaService] = &[
-        EthSepoliaService::Alchemy,
-        EthSepoliaService::BlockPi,
-        EthSepoliaService::Sepolia,
-    ];
+    const NON_DEFAULT_ETH_SEPOLIA_SERVICES: &'static [EthSepoliaService] =
+        &[EthSepoliaService::Alchemy, EthSepoliaService::Sepolia];
 
     const DEFAULT_L2_MAINNET_SERVICES: &'static [L2MainnetService] = &[
         L2MainnetService::Ankr,

--- a/src/rpc_client/tests.rs
+++ b/src/rpc_client/tests.rs
@@ -541,8 +541,16 @@ mod eth_get_transaction_count {
 }
 
 mod providers {
+    use crate::arbitrary::{arb_custom_rpc_services, arb_rpc_services};
     use crate::rpc_client::Providers;
-    use evm_rpc_types::{EthMainnetService, EthSepoliaService, L2MainnetService};
+    use assert_matches::assert_matches;
+    use evm_rpc_types::{
+        ConsensusStrategy, EthMainnetService, EthSepoliaService, L2MainnetService, ProviderError,
+        RpcService, RpcServices,
+    };
+    use maplit::btreeset;
+    use proptest::arbitrary::any;
+    use proptest::proptest;
     use std::collections::BTreeSet;
     use std::fmt::Debug;
 
@@ -579,5 +587,153 @@ mod providers {
             &Providers::NON_DEFAULT_L2_MAINNET_SERVICES,
             &L2MainnetService::all(),
         )
+    }
+
+    proptest! {
+        #[test]
+        fn should_choose_custom_providers(
+            not_enough_custom_providers in arb_custom_rpc_services(0..=3),
+            custom_providers in arb_custom_rpc_services(4..=4),
+            too_many_custom_providers in arb_custom_rpc_services(5..=10)
+        ) {
+            let strategy = ConsensusStrategy::Threshold {
+                num_providers: Some(4),
+                min_num_ok: 3,
+            };
+
+            let providers = Providers::new(
+                not_enough_custom_providers,
+                strategy.clone(),
+            );
+            assert_matches!(providers, Err(ProviderError::InvalidRpcConfig(_)));
+
+             let providers = Providers::new(
+                too_many_custom_providers,
+                strategy.clone(),
+            );
+            assert_matches!(providers, Err(ProviderError::InvalidRpcConfig(_)));
+
+            let _providers = Providers::new(
+                custom_providers.clone(),
+                strategy,
+            ).unwrap();
+        }
+    }
+
+    #[test]
+    fn should_choose_default_providers_first() {
+        let strategy = ConsensusStrategy::Threshold {
+            num_providers: Some(4),
+            min_num_ok: 3,
+        };
+
+        let providers = Providers::new(RpcServices::EthMainnet(None), strategy.clone()).unwrap();
+        assert_eq!(
+            providers.services,
+            btreeset! {
+                Providers::DEFAULT_ETH_MAINNET_SERVICES[0],
+                Providers::DEFAULT_ETH_MAINNET_SERVICES[1],
+                Providers::DEFAULT_ETH_MAINNET_SERVICES[2],
+                EthMainnetService::Alchemy,
+            }
+            .into_iter()
+            .map(RpcService::EthMainnet)
+            .collect()
+        );
+
+        let providers = Providers::new(RpcServices::EthSepolia(None), strategy.clone()).unwrap();
+        assert_eq!(
+            providers.services,
+            btreeset! {
+                Providers::DEFAULT_ETH_SEPOLIA_SERVICES[0],
+                Providers::DEFAULT_ETH_SEPOLIA_SERVICES[1],
+                Providers::DEFAULT_ETH_SEPOLIA_SERVICES[2],
+                EthSepoliaService::Alchemy,
+            }
+            .into_iter()
+            .map(RpcService::EthSepolia)
+            .collect()
+        );
+
+        let providers = Providers::new(RpcServices::ArbitrumOne(None), strategy.clone()).unwrap();
+        assert_eq!(
+            providers.services,
+            btreeset! {
+                Providers::DEFAULT_L2_MAINNET_SERVICES[0],
+                Providers::DEFAULT_L2_MAINNET_SERVICES[1],
+                Providers::DEFAULT_L2_MAINNET_SERVICES[2],
+                L2MainnetService::Alchemy,
+            }
+            .into_iter()
+            .map(RpcService::ArbitrumOne)
+            .collect()
+        );
+    }
+
+    #[test]
+    fn should_fail_when_threshold_unspecified_with_default_providers() {
+        let strategy = ConsensusStrategy::Threshold {
+            num_providers: None,
+            min_num_ok: 3,
+        };
+
+        for default_services in [
+            RpcServices::EthMainnet(None),
+            RpcServices::EthSepolia(None),
+            RpcServices::ArbitrumOne(None),
+            RpcServices::BaseMainnet(None),
+            RpcServices::OptimismMainnet(None),
+        ] {
+            let providers = Providers::new(default_services, strategy.clone());
+            assert_matches!(providers, Err(ProviderError::InvalidRpcConfig(_)));
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn should_fail_when_threshold_larger_than_number_of_supported_providers(min_num_ok in any::<u8>()) {
+            for (default_services, max_num_providers) in [
+                (
+                    RpcServices::EthMainnet(None),
+                    EthMainnetService::all().len(),
+                ),
+                (
+                    RpcServices::EthSepolia(None),
+                    EthSepoliaService::all().len(),
+                ),
+                (
+                    RpcServices::ArbitrumOne(None),
+                    L2MainnetService::all().len(),
+                ),
+                (
+                    RpcServices::BaseMainnet(None),
+                    L2MainnetService::all().len(),
+                ),
+                (
+                    RpcServices::OptimismMainnet(None),
+                    L2MainnetService::all().len(),
+                ),
+            ] {
+                let strategy = ConsensusStrategy::Threshold {
+                    num_providers: Some((max_num_providers + 1) as u8),
+                    min_num_ok,
+                };
+                let providers = Providers::new(default_services, strategy);
+                assert_matches!(providers, Err(ProviderError::InvalidRpcConfig(_)));
+            }
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn should_fail_when_threshold_invalid(services in arb_rpc_services()) {
+            let strategy = ConsensusStrategy::Threshold {
+                num_providers: Some(4),
+                min_num_ok: 5,
+            };
+
+            let providers = Providers::new(services, strategy.clone());
+            assert_matches!(providers, Err(ProviderError::InvalidRpcConfig(_)));
+        }
     }
 }

--- a/src/rpc_client/tests.rs
+++ b/src/rpc_client/tests.rs
@@ -539,3 +539,45 @@ mod eth_get_transaction_count {
         assert_eq!(count, TransactionCount::from(0x3d8_u32));
     }
 }
+
+mod providers {
+    use crate::rpc_client::Providers;
+    use evm_rpc_types::{EthMainnetService, EthSepoliaService, L2MainnetService};
+    use std::collections::BTreeSet;
+    use std::fmt::Debug;
+
+    #[test]
+    fn should_partition_providers_between_default_and_non_default() {
+        fn assert_is_partition<T: Debug + Ord>(left: &[T], right: &[T], all: &[T]) {
+            let left_set = left.iter().collect::<BTreeSet<_>>();
+            let right_set = right.iter().collect::<BTreeSet<_>>();
+            let all_set = all.iter().collect::<BTreeSet<_>>();
+
+            assert!(
+                left_set.is_disjoint(&right_set),
+                "Non-empty intersection {:?}",
+                left_set.intersection(&right_set).collect::<Vec<_>>()
+            );
+            assert_eq!(
+                left_set.union(&right_set).copied().collect::<BTreeSet<_>>(),
+                all_set
+            );
+        }
+
+        assert_is_partition(
+            &Providers::DEFAULT_ETH_MAINNET_SERVICES,
+            &Providers::NON_DEFAULT_ETH_MAINNET_SERVICES,
+            &EthMainnetService::all(),
+        );
+        assert_is_partition(
+            &Providers::DEFAULT_ETH_SEPOLIA_SERVICES,
+            &Providers::NON_DEFAULT_ETH_SEPOLIA_SERVICES,
+            &EthSepoliaService::all(),
+        );
+        assert_is_partition(
+            &Providers::DEFAULT_L2_MAINNET_SERVICES,
+            &Providers::NON_DEFAULT_L2_MAINNET_SERVICES,
+            &L2MainnetService::all(),
+        )
+    }
+}

--- a/src/rpc_client/tests.rs
+++ b/src/rpc_client/tests.rs
@@ -1,6 +1,7 @@
 mod eth_rpc_client {
     use crate::rpc_client::EthRpcClient;
     use evm_rpc_types::{EthMainnetService, ProviderError, RpcService, RpcServices};
+    use maplit::btreeset;
 
     #[test]
     fn should_fail_when_providers_explicitly_set_to_empty() {
@@ -49,10 +50,10 @@ mod eth_rpc_client {
 
         assert_eq!(
             client.providers(),
-            &[
+            &btreeset! {
                 RpcService::EthMainnet(provider1),
                 RpcService::EthMainnet(provider2)
-            ]
+            }
         );
     }
 }

--- a/src/rpc_client/tests.rs
+++ b/src/rpc_client/tests.rs
@@ -731,7 +731,13 @@ mod providers {
                 num_providers: Some(4),
                 min_num_ok: 5,
             };
+            let providers = Providers::new(services.clone(), strategy.clone());
+            assert_matches!(providers, Err(ProviderError::InvalidRpcConfig(_)));
 
+             let strategy = ConsensusStrategy::Threshold {
+                num_providers: Some(4),
+                min_num_ok: 0,
+            };
             let providers = Providers::new(services, strategy.clone());
             assert_matches!(providers, Err(ProviderError::InvalidRpcConfig(_)));
         }

--- a/src/rpc_client/tests.rs
+++ b/src/rpc_client/tests.rs
@@ -573,19 +573,19 @@ mod providers {
         }
 
         assert_is_partition(
-            &Providers::DEFAULT_ETH_MAINNET_SERVICES,
-            &Providers::NON_DEFAULT_ETH_MAINNET_SERVICES,
-            &EthMainnetService::all(),
+            Providers::DEFAULT_ETH_MAINNET_SERVICES,
+            Providers::NON_DEFAULT_ETH_MAINNET_SERVICES,
+            EthMainnetService::all(),
         );
         assert_is_partition(
-            &Providers::DEFAULT_ETH_SEPOLIA_SERVICES,
-            &Providers::NON_DEFAULT_ETH_SEPOLIA_SERVICES,
-            &EthSepoliaService::all(),
+            Providers::DEFAULT_ETH_SEPOLIA_SERVICES,
+            Providers::NON_DEFAULT_ETH_SEPOLIA_SERVICES,
+            EthSepoliaService::all(),
         );
         assert_is_partition(
-            &Providers::DEFAULT_L2_MAINNET_SERVICES,
-            &Providers::NON_DEFAULT_L2_MAINNET_SERVICES,
-            &L2MainnetService::all(),
+            Providers::DEFAULT_L2_MAINNET_SERVICES,
+            Providers::NON_DEFAULT_L2_MAINNET_SERVICES,
+            L2MainnetService::all(),
         )
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1344,6 +1344,7 @@ fn should_use_custom_response_size_estimate() {
             RpcServices::EthMainnet(Some(vec![EthMainnetService::Cloudflare])),
             Some(evm_rpc_types::RpcConfig {
                 response_size_estimate: Some(max_response_bytes),
+                response_consensus: None,
             }),
             evm_rpc_types::GetLogsArgs {
                 addresses: vec!["0xdAC17F958D2ee523a2206206994597C13D831ec7"


### PR DESCRIPTION
Introduce a new parameter in `RpcConfig` to let the caller choose between different consensus strategies to aggregate answers from multiple providers. Two strategies are defined, with the possibility of adding more in the future:

1. `Equality`: this is the default and matches the current behaviour, where all responses are expected to be non-error cases and all responses are expected to be equal.
2. `Threshold`: new strategy introduced by this PR, allowing to relax the aforementioned equality strategy to only a subset of the responses. Choosing this strategy may influence the chosen providers to match the specified threshold parameters. The implementation of responses aggregation in this case is done in a separate PR (#287).

