### PR TITLE
chore: Remove dependencies on the IC repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,7 +1355,6 @@ dependencies = [
  "hex",
  "ic-base-types",
  "ic-canister-log",
- "ic-canisters-http-types",
  "ic-cdk",
  "ic-cdk-macros",
  "ic-certified-map",
@@ -2105,16 +2104,6 @@ dependencies = [
  "serde_json",
  "slog",
  "which",
-]
-
-[[package]]
-name = "ic-canisters-http-types"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
-dependencies = [
- "candid",
- "serde",
- "serde_bytes",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,12 +1539,12 @@ dependencies = [
  "ic-cdk-macros",
  "ic-certified-map",
  "ic-config",
- "ic-crypto-sha3",
  "ic-crypto-test-utils-reproducible-rng",
  "ic-ethereum-types",
  "ic-ic00-types",
  "ic-metrics-encoder",
  "ic-nervous-system-common",
+ "ic-sha3",
  "ic-stable-structures",
  "ic-state-machine-tests",
  "ic-test-utilities-load-wasm",
@@ -3001,14 +3001,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-crypto-sha3"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
-dependencies = [
- "sha3",
-]
-
-[[package]]
 name = "ic-crypto-standalone-sig-verifier"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
@@ -3225,11 +3217,12 @@ dependencies = [
 
 [[package]]
 name = "ic-ethereum-types"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da075628cbdfdc80e052bacb02c0e8cafc49b9cf246ac64ac42a3707671e542"
 dependencies = [
  "hex",
- "ic-crypto-sha3",
+ "ic-sha3",
  "minicbor",
  "minicbor-derive",
  "serde",
@@ -3738,6 +3731,15 @@ dependencies = [
  "slog",
  "tempfile",
  "uuid",
+]
+
+[[package]]
+name = "ic-sha3"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3715f0f4370e8ce6aa9805b81e915ef4420c9dfb5209c71489c27e6f98bd5d65"
+dependencies = [
+ "sha3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,17 +34,6 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.15",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -428,105 +417,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
-dependencies = [
- "borsh-derive",
- "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
-dependencies = [
- "once_cell",
- "proc-macro-crate 3.2.0",
- "proc-macro2",
- "quote",
- "syn 2.0.77",
- "syn_derive",
-]
-
-[[package]]
-name = "build-info"
-version = "0.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "242c6293ad5acf5d9adb75231c1bd0c9cb0aecb64dd40e6579e36e0da7260f9b"
-dependencies = [
- "build-info-proc",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "build-info-build"
-version = "0.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebfef0dcb94d65cc2cd98ce285de89ed40c9a1d2bb10175f548867d0e26cda0"
-dependencies = [
- "anyhow",
- "base64 0.13.1",
- "bincode",
- "build-info-common",
- "cargo_metadata",
- "chrono",
- "glob",
- "lazy_static",
- "pretty_assertions",
- "rustc_version",
- "serde_json",
- "xz2",
-]
-
-[[package]]
-name = "build-info-common"
-version = "0.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db629469a6955021b15eb99cf5983ae8dcf9d0432ba2a8295715efee232da912"
-dependencies = [
- "chrono",
- "derive_more 0.99.18",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "build-info-proc"
-version = "0.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0965fa7159aa2cee4c5428ccec2d09dabb6ac5db2fe80d81cb8a158f5c47b335"
-dependencies = [
- "anyhow",
- "base64 0.13.1",
- "bincode",
- "build-info-common",
- "chrono",
- "format-buf",
- "num-bigint 0.4.6",
- "num-traits",
- "proc-macro-error",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 1.0.109",
- "xz2",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
-
-[[package]]
-name = "by_address"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "byte-slice-cast"
@@ -542,28 +436,6 @@ checksum = "da78b32057b8fdfc352504708feeba7216dcd65a2c9ab02978cbd288d1279b6c"
 dependencies = [
  "serde",
  "utf8-width",
-]
-
-[[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -683,12 +555,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
 name = "chrono"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,7 +564,6 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
@@ -1195,48 +1060,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dfn_candid"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
-dependencies = [
- "candid",
- "dfn_core",
- "ic-base-types",
- "on_wire",
- "serde",
-]
-
-[[package]]
-name = "dfn_core"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
-dependencies = [
- "ic-base-types",
- "on_wire",
-]
-
-[[package]]
-name = "dfn_protobuf"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
-dependencies = [
- "dfn_core",
- "ic-base-types",
- "on_wire",
- "prost",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -1290,12 +1117,6 @@ dependencies = [
  "quote",
  "syn 2.0.77",
 ]
-
-[[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "e2e"
@@ -1533,7 +1354,7 @@ dependencies = [
  "getrandom 0.2.15",
  "hex",
  "ic-base-types",
- "ic-canister-log 0.2.0 (git+https://github.com/dfinity/ic?rev=b7b0e54832bbe6bf4b80a2f75f4252699f5878e0)",
+ "ic-canister-log",
  "ic-canisters-http-types",
  "ic-cdk",
  "ic-cdk-macros",
@@ -1543,7 +1364,6 @@ dependencies = [
  "ic-ethereum-types",
  "ic-ic00-types",
  "ic-metrics-encoder",
- "ic-nervous-system-common",
  "ic-sha3",
  "ic-stable-structures",
  "ic-state-machine-tests",
@@ -1653,15 +1473,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,18 +1486,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "format-buf"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7aea5a5909a74969507051a3b17adc84737e31a5f910559892aedce026f4d53"
-
-[[package]]
-name = "fragile"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "funty"
@@ -1856,12 +1655,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,9 +1716,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1933,7 +1723,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
 ]
 
 [[package]]
@@ -2235,14 +2025,6 @@ dependencies = [
 name = "ic-canister-log"
 version = "0.2.0"
 source = "git+https://github.com/dfinity/ic?rev=b7b0e54832bbe6bf4b80a2f75f4252699f5878e0#b7b0e54832bbe6bf4b80a2f75f4252699f5878e0"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "ic-canister-log"
-version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
 dependencies = [
  "serde",
 ]
@@ -3305,28 +3087,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-icrc1"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
-dependencies = [
- "candid",
- "ciborium",
- "hex",
- "ic-base-types",
- "ic-crypto-sha2",
- "ic-ledger-canister-core",
- "ic-ledger-core",
- "ic-ledger-hash-of",
- "icrc-ledger-types",
- "num-bigint 0.4.6",
- "num-traits",
- "serde",
- "serde_bytes",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
 name = "ic-interfaces"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
@@ -3381,46 +3141,6 @@ dependencies = [
  "ic-types",
  "phantom_newtype",
  "thiserror",
-]
-
-[[package]]
-name = "ic-ledger-canister-core"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
-dependencies = [
- "async-trait",
- "candid",
- "ic-base-types",
- "ic-canister-log 0.2.0 (git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01)",
- "ic-constants",
- "ic-ic00-types",
- "ic-ledger-core",
- "ic-ledger-hash-of",
- "ic-utils",
- "num-traits",
- "serde",
-]
-
-[[package]]
-name = "ic-ledger-core"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
-dependencies = [
- "candid",
- "ic-ledger-hash-of",
- "num-traits",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "ic-ledger-hash-of"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
-dependencies = [
- "candid",
- "hex",
- "serde",
 ]
 
 [[package]]
@@ -3499,57 +3219,6 @@ name = "ic-metrics-encoder"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
-
-[[package]]
-name = "ic-nervous-system-common"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
-dependencies = [
- "anyhow",
- "async-trait",
- "build-info",
- "build-info-build",
- "by_address",
- "bytes",
- "candid",
- "dfn_candid",
- "dfn_core",
- "dfn_protobuf",
- "ic-base-types",
- "ic-canister-log 0.2.0 (git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01)",
- "ic-canisters-http-types",
- "ic-crypto-sha2",
- "ic-ic00-types",
- "ic-icrc1",
- "ic-ledger-core",
- "ic-metrics-encoder",
- "ic-nervous-system-runtime",
- "ic-nns-constants",
- "ic-stable-structures",
- "icp-ledger",
- "icrc-ledger-types",
- "json5",
- "maplit",
- "mockall",
- "priority-queue",
- "prost",
- "rust_decimal",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "ic-nervous-system-runtime"
-version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
-dependencies = [
- "async-trait",
- "candid",
- "dfn_candid",
- "dfn_core",
- "ic-base-types",
- "ic-cdk",
-]
 
 [[package]]
 name = "ic-nns-constants"
@@ -4063,51 +3732,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icp-ledger"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
-dependencies = [
- "candid",
- "comparable",
- "crc32fast",
- "dfn_candid",
- "dfn_core",
- "dfn_protobuf",
- "hex",
- "ic-base-types",
- "ic-crypto-sha2",
- "ic-ledger-canister-core",
- "ic-ledger-core",
- "ic-ledger-hash-of",
- "icrc-ledger-types",
- "lazy_static",
- "num-traits",
- "on_wire",
- "prost",
- "prost-derive",
- "serde",
- "serde_bytes",
- "serde_cbor",
- "strum 0.24.1",
- "strum_macros 0.24.3",
-]
-
-[[package]]
-name = "icrc-ledger-types"
-version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
-dependencies = [
- "base32",
- "candid",
- "crc32fast",
- "hex",
- "num-traits",
- "serde",
- "serde_bytes",
- "sha2 0.10.8",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4443,17 +4067,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 
 [[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4578,33 +4191,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4638,12 +4224,6 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
-
-[[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num"
@@ -4859,11 +4439,6 @@ checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
 dependencies = [
  "asn1-rs",
 ]
-
-[[package]]
-name = "on_wire"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
 
 [[package]]
 name = "once_cell"
@@ -5196,12 +4771,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5221,36 +4790,6 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "predicates"
-version = "2.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
-dependencies = [
- "difflib",
- "float-cmp",
- "itertools 0.10.5",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
-dependencies = [
- "predicates-core",
- "termtree",
-]
 
 [[package]]
 name = "pretty"
@@ -5307,16 +4846,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "priority-queue"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bda9164fe05bc9225752d54aae413343c36f684380005398a6a8fde95fe785"
-dependencies = [
- "autocfg",
- "indexmap 1.9.3",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5358,12 +4887,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -5492,26 +5015,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa37f80ca58604976033fae9515a8a2989fc13797d953f7c04fb8fa36a11f205"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -5706,15 +5209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5752,35 +5246,6 @@ dependencies = [
  "spin 0.9.8",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rkyv"
-version = "0.7.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -5830,22 +5295,6 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
-dependencies = [
- "arrayvec 0.7.6",
- "borsh",
- "bytes",
- "num-traits",
- "rand",
- "rkyv",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -6011,12 +5460,6 @@ dependencies = [
  "ring 0.17.8",
  "untrusted 0.9.0",
 ]
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
@@ -6192,12 +5635,6 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "simple_asn1"
@@ -6386,12 +5823,6 @@ checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-
-[[package]]
-name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
@@ -6406,19 +5837,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
  "heck 0.3.3",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -6481,18 +5899,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.77",
 ]
 
 [[package]]
@@ -6598,12 +6004,6 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "termtree"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "textwrap"
@@ -7725,15 +7125,6 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time",
-]
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ getrandom = { workspace = true }
 ic-canisters-http-types = { workspace = true }
 ic-sha3 = "1.0.0"
 ic-ethereum-types = "1.0.0"
-ic-nervous-system-common = { workspace = true }
 ic-metrics-encoder = { workspace = true }
 ic-stable-structures = { workspace = true }
 ic-canister-log = { git = "https://github.com/dfinity/ic", rev = "b7b0e54832bbe6bf4b80a2f75f4252699f5878e0", package = "ic-canister-log" }
@@ -72,7 +71,6 @@ ic-cdk = "0.10"
 ic-cdk-bindgen = "0.1"
 ic-cdk-macros = "0.7"
 ic-certified-map = "0.4"
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
 ic-metrics-encoder = "1.1"
 ic-stable-structures = "0.5"
 minicbor = { version = "0.19.1", features = ["alloc", "derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ ethnum = { workspace = true }
 evm_rpc_types = { path = "evm_rpc_types" }
 futures = { workspace = true }
 getrandom = { workspace = true }
-ic-canisters-http-types = { workspace = true }
 ic-sha3 = "1.0.0"
 ic-ethereum-types = "1.0.0"
 ic-metrics-encoder = { workspace = true }
@@ -39,6 +38,7 @@ num-bigint = { workspace = true }
 num-traits = "0.2"
 num-derive = "0.4"
 serde = { workspace = true }
+serde_bytes = { workspace = true }
 serde_json = { workspace = true }
 thousands = "0.2"
 url = "2.5"
@@ -57,7 +57,6 @@ ic-test-utilities-load-wasm = { git = "https://github.com/dfinity/ic", rev = "re
 itertools = "0.13"
 maplit = "1"
 proptest = { workspace = true }
-serde_bytes = { workspace = true }
 rand = "0.8"
 
 [workspace.dependencies]
@@ -66,7 +65,6 @@ ethnum = { version = "1.5.0", features = ["serde"] }
 futures = "0.3.30"
 getrandom = { version = "0.2", features = ["custom"] }
 hex = "0.4.3"
-ic-canisters-http-types = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
 ic-cdk = "0.10"
 ic-cdk-bindgen = "0.1"
 ic-cdk-macros = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ evm_rpc_types = { path = "evm_rpc_types" }
 futures = { workspace = true }
 getrandom = { workspace = true }
 ic-canisters-http-types = { workspace = true }
-ic-crypto-sha3 = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
-ic-ethereum-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
+ic-sha3 = "1.0.0"
+ic-ethereum-types = "1.0.0"
 ic-nervous-system-common = { workspace = true }
 ic-metrics-encoder = { workspace = true }
 ic-stable-structures = { workspace = true }

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -186,10 +186,5 @@ pub(super) fn into_hash(value: Hex32) -> Hash {
 }
 
 fn from_address(value: ic_ethereum_types::Address) -> evm_rpc_types::Hex20 {
-    // TODO 243: ic_ethereum_types::Address should expose the underlying [u8; 20]
-    // so that there is no artificial error handling here.
-    value
-        .to_string()
-        .parse()
-        .expect("BUG: Ethereum address cannot be parsed")
+    evm_rpc_types::Hex20::from(value.into_bytes())
 }

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -2,7 +2,7 @@
 
 use crate::rpc_client::json::requests::BlockSpec;
 use crate::rpc_client::json::Hash;
-use evm_rpc_types::BlockTag;
+use evm_rpc_types::{BlockTag, Hex20};
 use evm_rpc_types::{Hex, Hex256, Hex32, HexByte, Nat256};
 
 pub(super) fn into_block_spec(value: BlockTag) -> BlockSpec {
@@ -49,8 +49,9 @@ pub(super) fn from_log_entries(
 }
 
 fn from_log_entry(value: crate::rpc_client::json::responses::LogEntry) -> evm_rpc_types::LogEntry {
+    let value1 = value.address;
     evm_rpc_types::LogEntry {
-        address: from_address(value.address),
+        address: evm_rpc_types::Hex20::from(value1.into_bytes()),
         topics: value
             .topics
             .into_iter()
@@ -107,6 +108,7 @@ pub(super) fn into_get_transaction_count_params(
 pub(super) fn from_transaction_receipt(
     value: crate::rpc_client::json::responses::TransactionReceipt,
 ) -> evm_rpc_types::TransactionReceipt {
+    let value1 = value.from;
     evm_rpc_types::TransactionReceipt {
         block_hash: Hex32::from(value.block_hash.into_bytes()),
         block_number: value.block_number.into(),
@@ -117,17 +119,20 @@ pub(super) fn from_transaction_receipt(
             crate::rpc_client::json::responses::TransactionStatus::Failure => Nat256::from(0_u8),
         }),
         transaction_hash: Hex32::from(value.transaction_hash.into_bytes()),
-        contract_address: value.contract_address.map(from_address),
-        from: from_address(value.from),
+        contract_address: value
+            .contract_address
+            .map(|address| Hex20::from(address.into_bytes())),
+        from: evm_rpc_types::Hex20::from(value1.into_bytes()),
         logs: from_log_entries(value.logs),
         logs_bloom: Hex256::from(value.logs_bloom.into_bytes()),
-        to: value.to.map(from_address),
+        to: value.to.map(|address| Hex20::from(address.into_bytes())),
         transaction_index: value.transaction_index.into(),
         tx_type: HexByte::from(value.tx_type.into_byte()),
     }
 }
 
 pub(super) fn from_block(value: crate::rpc_client::json::responses::Block) -> evm_rpc_types::Block {
+    let value1 = value.miner;
     evm_rpc_types::Block {
         base_fee_per_gas: value.base_fee_per_gas.map(Nat256::from),
         number: value.number.into(),
@@ -137,7 +142,7 @@ pub(super) fn from_block(value: crate::rpc_client::json::responses::Block) -> ev
         gas_used: value.gas_used.into(),
         hash: Hex32::from(value.hash.into_bytes()),
         logs_bloom: Hex256::from(value.logs_bloom.into_bytes()),
-        miner: from_address(value.miner),
+        miner: evm_rpc_types::Hex20::from(value1.into_bytes()),
         mix_hash: Hex32::from(value.mix_hash.into_bytes()),
         nonce: value.nonce.into(),
         parent_hash: Hex32::from(value.parent_hash.into_bytes()),
@@ -183,8 +188,4 @@ pub(super) fn from_send_raw_transaction_result(
 
 pub(super) fn into_hash(value: Hex32) -> Hash {
     Hash::new(value.into())
-}
-
-fn from_address(value: ic_ethereum_types::Address) -> evm_rpc_types::Hex20 {
-    evm_rpc_types::Hex20::from(value.into_bytes())
 }

--- a/src/http_types/mod.rs
+++ b/src/http_types/mod.rs
@@ -1,0 +1,106 @@
+//! Copy of the types from the unpublished [`ic-canisters-http-types`](https://github.com/dfinity/ic/blob/f4242cbcf83f0725663f3cd1a6b3a83eb2dace01/rs/rust_canisters/http_types/src/lib.rs) crate.
+
+#[cfg(test)]
+mod tests;
+
+use candid::{CandidType, Deserialize};
+use serde_bytes::ByteBuf;
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct HttpRequest {
+    pub method: String,
+    pub url: String,
+    pub headers: Vec<(String, String)>,
+    pub body: ByteBuf,
+}
+
+impl HttpRequest {
+    pub fn path(&self) -> &str {
+        match self.url.find('?') {
+            None => &self.url[..],
+            Some(index) => &self.url[..index],
+        }
+    }
+
+    /// Searches for the first appearance of a parameter in the request URL.
+    /// Returns `None` if the given parameter does not appear in the query.
+    pub fn raw_query_param(&self, param: &str) -> Option<&str> {
+        const QUERY_SEPARATOR: &str = "?";
+        let query_string = self.url.split(QUERY_SEPARATOR).nth(1)?;
+        if query_string.is_empty() {
+            return None;
+        }
+        const PARAMETER_SEPARATOR: &str = "&";
+        for chunk in query_string.split(PARAMETER_SEPARATOR) {
+            const KEY_VALUE_SEPARATOR: &str = "=";
+            let mut split = chunk.splitn(2, KEY_VALUE_SEPARATOR);
+            let name = split.next()?;
+            if name == param {
+                return Some(split.next().unwrap_or_default());
+            }
+        }
+        None
+    }
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct HttpResponse {
+    pub status_code: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: ByteBuf,
+}
+
+pub struct HttpResponseBuilder(HttpResponse);
+
+impl HttpResponseBuilder {
+    pub fn ok() -> Self {
+        Self(HttpResponse {
+            status_code: 200,
+            headers: vec![],
+            body: ByteBuf::default(),
+        })
+    }
+
+    pub fn bad_request() -> Self {
+        Self(HttpResponse {
+            status_code: 400,
+            headers: vec![],
+            body: ByteBuf::from("bad request"),
+        })
+    }
+
+    pub fn not_found() -> Self {
+        Self(HttpResponse {
+            status_code: 404,
+            headers: vec![],
+            body: ByteBuf::from("not found"),
+        })
+    }
+
+    pub fn server_error(reason: impl ToString) -> Self {
+        Self(HttpResponse {
+            status_code: 500,
+            headers: vec![],
+            body: ByteBuf::from(reason.to_string()),
+        })
+    }
+
+    pub fn header(mut self, name: impl ToString, value: impl ToString) -> Self {
+        self.0.headers.push((name.to_string(), value.to_string()));
+        self
+    }
+
+    pub fn body(mut self, bytes: impl Into<Vec<u8>>) -> Self {
+        self.0.body = ByteBuf::from(bytes.into());
+        self
+    }
+
+    pub fn with_body_and_content_length(self, bytes: impl Into<Vec<u8>>) -> Self {
+        let bytes = bytes.into();
+        self.header("Content-Length", bytes.len()).body(bytes)
+    }
+
+    pub fn build(self) -> HttpResponse {
+        self.0
+    }
+}

--- a/src/http_types/tests.rs
+++ b/src/http_types/tests.rs
@@ -1,0 +1,20 @@
+use crate::http_types::HttpRequest;
+
+#[test]
+fn test_raw_query_param() {
+    fn request_with_url(url: String) -> HttpRequest {
+        HttpRequest {
+            method: "".to_string(),
+            url,
+            headers: vec![],
+            body: Default::default(),
+        }
+    }
+    let http_request = request_with_url("/endpoint?time=1000".to_string());
+    assert_eq!(http_request.raw_query_param("time"), Some("1000"));
+    let http_request = request_with_url("/endpoint".to_string());
+    assert_eq!(http_request.raw_query_param("time"), None);
+    let http_request =
+        request_with_url("/endpoint?time=1000&time=1001&other=abcde&time=1002".to_string());
+    assert_eq!(http_request.raw_query_param("time"), Some("1000"));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod accounting;
 pub mod candid_rpc;
 pub mod constants;
 pub mod http;
+pub mod http_types;
 pub mod logs;
 pub mod memory;
 pub mod metrics;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,12 @@ use evm_rpc::memory::{
 use evm_rpc::metrics::encode_metrics;
 use evm_rpc::providers::{find_provider, resolve_rpc_service, PROVIDERS, SERVICE_PROVIDER_MAP};
 use evm_rpc::types::{InstallArgs, Provider, ProviderId, RpcAccess};
-use evm_rpc::{http::{json_rpc_request, transform_http_request}, http_types, memory::UNSTABLE_METRICS, types::{MetricRpcMethod, Metrics}};
+use evm_rpc::{
+    http::{json_rpc_request, transform_http_request},
+    http_types,
+    memory::UNSTABLE_METRICS,
+    types::{MetricRpcMethod, Metrics},
+};
 use evm_rpc_types::{Hex32, MultiRpcResult, RpcResult};
 use ic_canister_log::log;
 use ic_cdk::api::is_controller;

--- a/src/rpc_client/eth_rpc/mod.rs
+++ b/src/rpc_client/eth_rpc/mod.rs
@@ -320,7 +320,7 @@ fn is_successful_http_code(status: &u16) -> bool {
 }
 
 fn sort_by_hash<T: Serialize + DeserializeOwned>(to_sort: &mut [T]) {
-    use ic_crypto_sha3::Keccak256;
+    use ic_sha3::Keccak256;
     to_sort.sort_by(|a, b| {
         let a_hash = Keccak256::hash(serde_json::to_vec(a).expect("BUG: failed to serialize"));
         let b_hash = Keccak256::hash(serde_json::to_vec(b).expect("BUG: failed to serialize"));

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -6,7 +6,6 @@ use evm_rpc_types::{
     RpcConfig, RpcError, RpcResult, RpcService, RpcServices,
 };
 use ic_canister_log::log;
-use ic_crypto_sha3::Keccak256;
 use json::requests::{
     BlockSpec, FeeHistoryParams, GetBlockByNumberParams, GetLogsParam, GetTransactionCountParams,
 };
@@ -642,6 +641,7 @@ impl<T: Debug + PartialEq + Serialize> ResponseDistribution<T> {
     }
 
     pub fn insert_once(&mut self, provider: RpcService, result: T) {
+        use ic_sha3::Keccak256;
         let hash = Keccak256::hash(serde_json::to_vec(&result).expect("BUG: failed to serialize"));
         match self.hashes.get(&hash) {
             Some(existing_result) => {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,6 +5,7 @@ use candid::{CandidType, Decode, Encode, Nat};
 use evm_rpc::logs::{Log, LogEntry};
 use evm_rpc::{
     constants::{CONTENT_TYPE_HEADER_LOWERCASE, CONTENT_TYPE_VALUE},
+    http_types::{HttpRequest, HttpResponse},
     providers::PROVIDERS,
     types::{InstallArgs, Metrics, ProviderId, RpcAccess, RpcMethod},
 };
@@ -14,7 +15,6 @@ use evm_rpc_types::{
     RpcService, RpcServices,
 };
 use ic_base_types::{CanisterId, PrincipalId};
-use ic_canisters_http_types::{HttpRequest, HttpResponse};
 use ic_cdk::api::management_canister::http_request::{
     CanisterHttpRequestArgument, HttpHeader, HttpMethod, HttpResponse as OutCallHttpResponse,
     TransformArgs, TransformContext, TransformFunc,


### PR DESCRIPTION
Remove all productive dependencies on the [IC repository](https://github.com/dfinity/ic/tree/master):

1. `ic-canisters-http-types`: is removed and the corresponding types (`HttpRequest` and `HttpResponse`) were copied over since they amount to a few lines of code.
2. `ic-crypto-sha3`: is replaced by `ic-sha3`, available on [crates.io](https://crates.io/crates/ic-sha3).
3. `ic-ethereum-types` is replaced by a crate of the same name available on[ crates.io](https://crates.io/crates/ic-ethereum-types).
4. `ic-nervous-system-common`: is removed since it was only used to serve metrics.

The only remaining productive dependency from the IC repository is `ic-canister-log` and will be removed by #241.