### PR TITLE
fix: maximum value for `max_response_bytes`

### DIFF
--- a/src/rpc_client/eth_rpc/mod.rs
+++ b/src/rpc_client/eth_rpc/mod.rs
@@ -37,8 +37,8 @@ mod tests;
 pub const HEADER_SIZE_LIMIT: u64 = 2 * 1024;
 
 // This constant comes from the IC specification:
-// > If provided, the value must not exceed 2MiB
-const HTTP_MAX_SIZE: u64 = 2 * 1024 * 1024;
+// > If provided, the value must not exceed 2MB
+const HTTP_MAX_SIZE: u64 = 2_000_000;
 
 pub const MAX_PAYLOAD_SIZE: u64 = HTTP_MAX_SIZE - HEADER_SIZE_LIMIT;
 


### PR DESCRIPTION
Fix a bug introduced by #279, where the constant `HTTP_MAX_SIZE` was changed from 2 MB to 2 MiB. This is wrong since per the [IC specification ](https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-http_request) `max_response_bytes` must be at most `2_000_000` bytes and HTTPs outcalls using a bigger value for `max_response_bytes` will be rejected.