### PR TITLE
refactor: improve debug and display representations

### DIFF
--- a/evm_rpc_types/CHANGELOG.md
+++ b/evm_rpc_types/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- v1.1.0 Improve Debug and Display implementations for `HexByte`, `Hex20`, `Hex32`, `Hex256`, `Hex` and `Nat256`.
+
 ## [1.0.0] - 2024-10-07
 
 ### Added

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -12,7 +12,7 @@ use candid::{CandidType, Nat};
 use hex::FromHexError;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
-use std::fmt::Formatter;
+use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
 
 pub use lifecycle::{InstallArgs, LogFilter, RegexString};
@@ -28,9 +28,21 @@ pub use rpc_client::{
 };
 
 /// A `Nat` that is guaranteed to fit in 256 bits.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "candid::Nat", into = "candid::Nat")]
 pub struct Nat256(Nat);
+
+impl Display for Nat256 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0 .0)
+    }
+}
+
+impl Debug for Nat256 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0 .0)
+    }
+}
 
 impl Nat256 {
     pub const ZERO: Nat256 = Nat256(Nat(BigUint::ZERO));
@@ -104,7 +116,7 @@ impl_from_unchecked!( Nat256, usize u8 u16 u32 u64 u128 );
 macro_rules! impl_hex_string {
     ($name: ident($data: ty)) => {
         #[doc = concat!("Ethereum hex-string (String representation is prefixed by 0x) wrapping a `", stringify!($data), "`. ")]
-        #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+        #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
         #[serde(try_from = "String", into = "String")]
         pub struct $name($data);
 
@@ -114,6 +126,13 @@ macro_rules! impl_hex_string {
                 f.write_str(&hex::encode(&self.0))
             }
         }
+
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self)
+            }
+        }
+
 
         impl From<$data> for $name {
             fn from(value: $data) -> Self {

--- a/evm_rpc_types/src/tests.rs
+++ b/evm_rpc_types/src/tests.rs
@@ -40,6 +40,14 @@ mod nat256 {
         }
     }
 
+    #[test]
+    fn should_have_transparent_debug_and_display_representation() {
+        let number = Nat256::from(0x68802B_u32);
+
+        assert_eq!(format!("{:?}", number), "6848555");
+        assert_eq!(format!("{}", number), "6848555");
+    }
+
     fn encode_decode_roundtrip(value: BigUint) {
         let nat = Nat::from(value);
         let encoded_nat = Encode!(&nat).unwrap();
@@ -104,6 +112,20 @@ mod hex_string {
             expect_decoding_error::<Hex256>(&short_hex256)?;
             expect_decoding_error::<Hex256>(&long_hex256)?;
         }
+    }
+
+    #[test]
+    fn should_have_ethereum_style_debug_format() {
+        let hex = Hex32::from([
+            115, 166, 64, 150, 180, 39, 93, 36, 71, 160, 156, 224, 104, 32, 54, 11, 239, 30, 208,
+            187, 226, 23, 212, 37, 216, 38, 46, 98, 221, 154, 234, 158,
+        ]);
+        let hex_debug = format!("{:?}", hex);
+
+        assert_eq!(
+            hex_debug,
+            "0x73a64096b4275d2447a09ce06820360bef1ed0bbe217d425d8262e62dd9aea9e"
+        )
     }
 
     #[test]


### PR DESCRIPTION
Improve `Debug` and `Display` implementations for `HexByte`, `Hex20`, `Hex32`, `Hex256`, `Hex` and `Nat256` to follow more closely the format of Ethereum instead of showing the internal representation (a byte array or a wrapper around a `Nat`)