### PR TITLE
refactor: Remove Ankr as a default provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* chore: changelog file
+* v2.1.0 chore: changelog file
+
+### Changed
+
+* v2.1.0 refactor: Remove Ankr as a default provider 
+
 
 ## [2.0.0] - 2024-10-08
 

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -54,31 +54,31 @@ pub struct Providers {
 
 impl Providers {
     const DEFAULT_ETH_MAINNET_SERVICES: &'static [EthMainnetService] = &[
-        EthMainnetService::Ankr,
+        EthMainnetService::BlockPi,
         EthMainnetService::Cloudflare,
         EthMainnetService::PublicNode,
     ];
     const NON_DEFAULT_ETH_MAINNET_SERVICES: &'static [EthMainnetService] = &[
         EthMainnetService::Alchemy,
-        EthMainnetService::BlockPi,
         EthMainnetService::Llama,
+        EthMainnetService::Ankr,
     ];
 
     const DEFAULT_ETH_SEPOLIA_SERVICES: &'static [EthSepoliaService] = &[
-        EthSepoliaService::Ankr,
+        EthSepoliaService::Sepolia,
         EthSepoliaService::BlockPi,
         EthSepoliaService::PublicNode,
     ];
     const NON_DEFAULT_ETH_SEPOLIA_SERVICES: &'static [EthSepoliaService] =
-        &[EthSepoliaService::Alchemy, EthSepoliaService::Sepolia];
+        &[EthSepoliaService::Alchemy, EthSepoliaService::Ankr];
 
     const DEFAULT_L2_MAINNET_SERVICES: &'static [L2MainnetService] = &[
-        L2MainnetService::Ankr,
+        L2MainnetService::Llama,
         L2MainnetService::BlockPi,
         L2MainnetService::PublicNode,
     ];
     const NON_DEFAULT_L2_MAINNET_SERVICES: &'static [L2MainnetService] =
-        &[L2MainnetService::Alchemy, L2MainnetService::Llama];
+        &[L2MainnetService::Alchemy, L2MainnetService::Ankr];
 
     pub fn new(source: RpcServices, strategy: ConsensusStrategy) -> Result<Self, ProviderError> {
         let (chain, providers): (_, BTreeSet<_>) = match source {

--- a/src/rpc_client/tests.rs
+++ b/src/rpc_client/tests.rs
@@ -576,6 +576,20 @@ mod providers {
         )
     }
 
+    // Note that changing the number of providers is a non-trivial operation
+    // that has consequences for all users of the EVM RPC canister:
+    // 1) Decreasing the number of providers is a breaking change:
+    //    - E.g. ConsensusStrategy::Threshold { total: Some(6), min: 3 } would fail
+    //      if the number of providers is decreased from 6 to 5.
+    // 2) Increasing the number of providers, while non-breaking, is a significant change
+    //    since that number can no longer be decreased afterwards without a breaking change.
+    #[test]
+    fn should_have_stable_number_of_providers() {
+        assert_eq!(EthMainnetService::all().len(), 6);
+        assert_eq!(EthSepoliaService::all().len(), 5);
+        assert_eq!(L2MainnetService::all().len(), 5);
+    }
+
     proptest! {
         #[test]
         fn should_choose_custom_providers(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -56,6 +56,7 @@ const RPC_SERVICES: &[RpcServices] = &[
 const ANKR_HOSTNAME: &str = "rpc.ankr.com";
 const ALCHEMY_ETH_MAINNET_HOSTNAME: &str = "eth-mainnet.g.alchemy.com";
 const CLOUDFLARE_HOSTNAME: &str = "cloudflare-eth.com";
+const BLOCKPI_ETH_HOSTNAME: &str = "ethereum.blockpi.network";
 const BLOCKPI_ETH_SEPOLIA_HOSTNAME: &str = "ethereum-sepolia.blockpi.network";
 const PUBLICNODE_ETH_MAINNET_HOSTNAME: &str = "ethereum-rpc.publicnode.com";
 
@@ -963,12 +964,12 @@ fn candid_rpc_should_err_when_service_unavailable() {
         setup.get_metrics(),
         Metrics {
             requests: hashmap! {
-                (rpc_method(), ANKR_HOSTNAME.into()) => 1,
+                (rpc_method(), BLOCKPI_ETH_HOSTNAME.into()) => 1,
                 (rpc_method(), CLOUDFLARE_HOSTNAME.into()) => 1,
                 (rpc_method(), PUBLICNODE_ETH_MAINNET_HOSTNAME.into()) => 1,
             },
             responses: hashmap! {
-                (rpc_method(), ANKR_HOSTNAME.into(), 503.into()) => 1,
+                (rpc_method(), BLOCKPI_ETH_HOSTNAME.into(), 503.into()) => 1,
                 (rpc_method(), CLOUDFLARE_HOSTNAME.into(), 503.into()) => 1,
                 (rpc_method(), PUBLICNODE_ETH_MAINNET_HOSTNAME.into(), 503.into()) => 1,
             },


### PR DESCRIPTION
`rpc.ankr.com` recently dropped its IPv6 connectivity and will need according to its support team a month to fix it (see this forum [post](https://forum.dfinity.org/t/cketh-a-canister-issued-ether-twin-token-on-the-ic/22819/204)) and is therefore unfit to be selected as a default provider in case the caller did not manually specify the requested providers. This PR replaces it with BlockPi (`ethereum.blockpi.network`), which has been so far working well for the [ckETH minter](https://dashboard.internetcomputer.org/canister/sv3dd-oaaaa-aaaar-qacoa-cai).