### PR TITLE
refactor: improve debug of `RpcApi`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,7 @@ dependencies = [
  "serde",
  "strum",
  "thiserror",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
 thousands = "0.2"
-url = "2.5"
+url = { workspace = true }
 hex = "0.4"
 ethers-core = "2.0"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
@@ -81,6 +81,7 @@ serde_json = "1.0"
 serde_bytes = "0.11.15"
 strum = { version = "0.26", features = ["derive"] }
 thiserror = "1.0.64"
+url = "2.5"
 
 [workspace]
 members = ["e2e/rust", "evm_rpc_types"]

--- a/evm_rpc_types/CHANGELOG.md
+++ b/evm_rpc_types/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - v1.1.0 Improve Debug and Display implementations for `HexByte`, `Hex20`, `Hex32`, `Hex256`, `Hex` and `Nat256`.
+- v1.1.0 Improve Debug implementation of `RpcApi`.
 
 ## [1.0.0] - 2024-10-07
 

--- a/evm_rpc_types/Cargo.toml
+++ b/evm_rpc_types/Cargo.toml
@@ -19,6 +19,7 @@ num-bigint = { workspace = true }
 serde = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/evm_rpc_types/src/rpc_client/mod.rs
+++ b/evm_rpc_types/src/rpc_client/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 pub use ic_cdk::api::management_canister::http_request::HttpHeader;
 use std::fmt::Debug;
 
@@ -53,9 +56,18 @@ pub struct RpcApi {
     pub headers: Option<Vec<HttpHeader>>,
 }
 
+impl RpcApi {
+    pub fn host_str(&self) -> Option<String> {
+        url::Url::parse(&self.url)
+            .ok()
+            .and_then(|u| u.host_str().map(|host| host.to_string()))
+    }
+}
+
 impl Debug for RpcApi {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "RpcApi {{ url: ***, headers: *** }}",) //URL or header value could contain API keys
+        let host = self.host_str().unwrap_or("N/A".to_string());
+        write!(f, "RpcApi {{ host: {}, url/headers: *** }}", host) //URL or header value could contain API keys
     }
 }
 

--- a/evm_rpc_types/src/rpc_client/tests.rs
+++ b/evm_rpc_types/src/rpc_client/tests.rs
@@ -1,0 +1,29 @@
+use crate::RpcApi;
+use ic_cdk::api::management_canister::http_request::HttpHeader;
+
+#[test]
+fn should_contain_host_without_sensitive_information() {
+    for provider in [
+        RpcApi {
+            url: "https://eth-mainnet.g.alchemy.com/v2".to_string(),
+            headers: None,
+        },
+        RpcApi {
+            url: "https://eth-mainnet.g.alchemy.com/v2/key".to_string(),
+            headers: None,
+        },
+        RpcApi {
+            url: "https://eth-mainnet.g.alchemy.com/v2".to_string(),
+            headers: Some(vec![HttpHeader {
+                name: "authorization".to_string(),
+                value: "Bearer key".to_string(),
+            }]),
+        },
+    ] {
+        let debug = format!("{:?}", provider);
+        assert_eq!(
+            debug,
+            "RpcApi { host: eth-mainnet.g.alchemy.com, url/headers: *** }"
+        );
+    }
+}


### PR DESCRIPTION
Improve debug representation of `RpcApi` to display the host name if available.