### PR TITLE
fix: Candid interface compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Fixed
 
 * v2.1.1 fix: ensure Candid API is the same as the interface exposed by the canister
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* v2.1.1 fix: ensure Candid API is the same as the interface exposed by the canister
+
 ## [2.1.0] - 2024-10-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "evm_rpc"
-version = "0.1.0"
+version = "2.1.0"
 dependencies = [
  "assert_matches",
  "candid",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "evm_rpc_types"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "candid",
  "hex",

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -192,9 +192,9 @@ type ConsensusStrategy = variant {
   Equality;
   Threshold : record {
     // Total number of providers to be queried. Can be omitted, if that number can be inferred (e.g., providers are specified in the request).
-    total : opt nat;
+    total : opt nat8;
     // Minimum number of providers that must return the same (non-error) result.
-    min : nat;
+    min : nat8;
   };
 };
 type RpcError = variant {
@@ -234,8 +234,8 @@ type SendRawTransactionStatus = variant {
 // See https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs
 type Topic = vec text;
 type TransactionReceipt = record {
-  to : text;
-  status : nat;
+  to : opt text;
+  status : opt nat;
   transactionHash : text;
   blockNumber : nat;
   from : text;
@@ -250,11 +250,7 @@ type TransactionReceipt = record {
 };
 type ValidationError = variant {
   Custom : text;
-  HostNotAllowed : text;
-  UrlParseError : text;
   InvalidHex : text;
-  CredentialPathNotAllowed;
-  CredentialHeaderNotAllowed;
 };
 service : (InstallArgs) -> {
   eth_feeHistory : (RpcServices, opt RpcConfig, FeeHistoryArgs) -> (MultiFeeHistoryResult);

--- a/evm_rpc_types/src/response/mod.rs
+++ b/evm_rpc_types/src/response/mod.rs
@@ -110,7 +110,7 @@ pub struct TransactionReceipt {
     #[serde(rename = "logsBloom")]
     pub logs_bloom: Hex256,
 
-    /// Address of the receiver or null in a contract creation transaction.
+    /// Address of the receiver or `None` in a contract creation transaction.
     pub to: Option<Hex20>,
 
     /// Transaction's index position in the block

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,7 +237,7 @@ async fn update_api_keys(api_keys: Vec<(ProviderId, Option<String>)>) {
     }
 }
 
-#[query(name = "__transform_json_rpc")]
+#[query(name = "__transform_json_rpc", hidden = true)]
 fn transform(args: TransformArgs) -> HttpResponse {
     transform_http_request(args)
 }
@@ -260,7 +260,7 @@ fn post_upgrade(args: evm_rpc_types::InstallArgs) {
     }
 }
 
-#[query]
+#[query(hidden = true)]
 fn http_request(request: http_types::HttpRequest) -> http_types::HttpResponse {
     match request.path() {
         "/metrics" => {
@@ -378,7 +378,7 @@ mod test {
             }
         }
 
-        fn check_service_compatible(
+        fn check_service_equal(
             new_name: &str,
             new: candid_parser::utils::CandidSource,
             old_name: &str,
@@ -386,11 +386,11 @@ mod test {
         ) {
             let new_str = source_to_str(&new);
             let old_str = source_to_str(&old);
-            match candid_parser::utils::service_compatible(new, old) {
+            match candid_parser::utils::service_equal(new, old) {
                 Ok(_) => {}
                 Err(e) => {
                     eprintln!(
-                        "{} is not compatible with {}!\n\n\
+                        "{} is not equal with {}!\n\n\
             {}:\n\
             {}\n\n\
             {}:\n\
@@ -409,7 +409,7 @@ mod test {
         let old_interface = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
             .join("candid/evm_rpc.did");
 
-        check_service_compatible(
+        check_service_equal(
             "actual ledger candid interface",
             candid_parser::utils::CandidSource::Text(&new_interface),
             "declared candid interface in evm_rpc.did file",


### PR DESCRIPTION
Ensure that the declared Candid interface is the same as the one exposed by the canister.